### PR TITLE
Add the 'typedb node' option for running a TypeDB Cluster Node

### DIFF
--- a/binary/typedb
+++ b/binary/typedb
@@ -63,18 +63,20 @@ elif [ "$1" = "console" ]; then
     fi
 elif [[ "$1" = "server" ]] || [[ "$1" = "node" ]]; then
     if [[ "$1" = "server" ]]; then
+        TYPEDB_ALL_NAME="TypeDB (All)"
         TYPEDB_SERVER_NAME="TypeDB (Server)"
-        TYPEDB_SERVER_MAIN=com.vaticle.typedb.core.server.TypeDBServer
-        SERVER_DIR="${TYPEDB_HOME}/server"
+        TYPEDB_SERVER_CLASS=com.vaticle.typedb.core.server.TypeDBServer
+        TYPEDB_SERVER_DIR="${TYPEDB_HOME}/server"
     else
+        TYPEDB_ALL_NAME="TypeDB Cluster (All)"
         TYPEDB_SERVER_NAME="TypeDB Cluster (Node)"
-        TYPEDB_SERVER_MAIN=com.vaticle.typedb.cluster.node.TypeDBNode
-        SERVER_DIR="${TYPEDB_HOME}/node"
+        TYPEDB_SERVER_CLASS=com.vaticle.typedb.cluster.node.TypeDBNode
+        TYPEDB_SERVER_DIR="${TYPEDB_HOME}/node"
     fi
-    LIB_DIR="${SERVER_DIR}/lib"
-    CLASSPATH="${SERVER_DIR}/conf/:${LIB_DIR}/common/*"
+    TYPEDB_SERVER_LIB_DIR="${TYPEDB_SERVER_DIR}/lib"
+    CLASSPATH="${TYPEDB_SERVER_DIR}/conf/:${TYPEDB_SERVER_LIB_DIR}/common/*"
 
-    if [[ -d "${SERVER_DIR}" ]]; then
+    if [[ -d "${TYPEDB_SERVER_DIR}" ]]; then
         IDX=0
         while [[ "${@:IDX}" ]]; do
             case ${@:IDX:1} in
@@ -87,23 +89,23 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "node" ]]; then
         # exec replaces current shell process with java so no commands after these ones will ever get executed
         if [ $DEBUG ]; then
             case "$(uname -s)" in
-                Darwin) CLASSPATH="${CLASSPATH}:$LIB_DIR/dev/*" ;;
+                Darwin) CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/dev/*" ;;
                 *) echo "WARNING: Debug mode RocksDB is not available in this platform. Fallback to production mode."
-                   CLASSPATH="${CLASSPATH}:$LIB_DIR/prod/*" ;;
+                   CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/prod/*" ;;
             esac
             exec $JAVA_BIN ${JAVAOPTS} -ea -cp "${CLASSPATH}" \
                 -Dtypedb.dir="${TYPEDB_HOME}" -Dtypedb.conf="${TYPEDB_HOME}/${TYPEDB_CONFIG}" \
                 -Dlogback.configurationFile=logback-debug.xml \
-                ${TYPEDB_SERVER_MAIN} "${@:2}"
+                ${TYPEDB_SERVER_CLASS} "${@:2}"
         else
-            CLASSPATH="${CLASSPATH}:$LIB_DIR/prod/*"
+            CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/prod/*"
             exec $JAVA_BIN ${JAVAOPTS} -cp "${CLASSPATH}" \
                 -Dtypedb.dir="${TYPEDB_HOME}" -Dtypedb.conf="${TYPEDB_HOME}/${TYPEDB_CONFIG}" \
-                ${TYPEDB_SERVER_MAIN} "${@:2}"
+                ${TYPEDB_SERVER_CLASS} "${@:2}"
         fi
     else
         echo "$TYPEDB_SERVER_NAME is not included in this TypeDB distribution."
-        echo "You may want to install $TYPEDB_SERVER_NAME or TypeDB (all)."
+        echo "You may want to install $TYPEDB_SERVER_NAME or $TYPEDB_ALL_NAME."
         exit 1
     fi
 else

--- a/binary/typedb
+++ b/binary/typedb
@@ -61,7 +61,7 @@ elif [ "$1" = "console" ]; then
         echo "You may want to install TypeDB Console or TypeDB (all)."
         exit 1
     fi
-elif [[ "$1" = "server" ]] || [[ "$1" = "node" ]] || [[ "$1" = "version" ]]; then
+elif [[ "$1" = "server" ]] || [[ "$1" = "node" ]]; then
     if [[ "$1" = "server" ]]; then
         TYPEDB_SERVER_NAME="TypeDB (Server)"
         TYPEDB_SERVER_MAIN=com.vaticle.typedb.core.server.TypeDBServer

--- a/binary/typedb
+++ b/binary/typedb
@@ -47,6 +47,7 @@ exit_if_java_not_found
 if [ -z "$1" ]; then
     echo "Missing argument. Possible commands are:"
     echo "  Server:          typedb server [--help]"
+    echo "  Node:            typedb node [--help]"
     echo "  Console:         typedb console [--help]"
     exit 1
 elif [ "$1" = "console" ]; then
@@ -54,14 +55,26 @@ elif [ "$1" = "console" ]; then
         SERVICE_LIB_CP="console/lib/*"
         CLASSPATH="${TYPEDB_HOME}/${SERVICE_LIB_CP}:${TYPEDB_HOME}/console/conf/"
     # exec replaces current shell process with java so no commands after this one will ever get executed
-        exec $JAVA_BIN ${CONSOLE_JAVAOPTS} -cp "${CLASSPATH}" -Dtypedb.dir="${TYPEDB_HOME}" com.vaticle.typedb.console.TypeDBConsole "${@:2}"
+        exec $JAVA_BIN ${JAVAOPTS} -cp "${CLASSPATH}" -Dtypedb.dir="${TYPEDB_HOME}" com.vaticle.typedb.console.TypeDBConsole "${@:2}"
     else
         echo "TypeDB Console is not included in this TypeDB distribution."
         echo "You may want to install TypeDB Console or TypeDB (all)."
         exit 1
     fi
-elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
-    if [[ -d "${TYPEDB_HOME}/server" ]]; then
+elif [[ "$1" = "server" ]] || [[ "$1" = "node" ]] || [[ "$1" = "version" ]]; then
+    if [[ "$1" = "server" ]]; then
+        TYPEDB_SERVER_NAME="TypeDB (Server)"
+        TYPEDB_SERVER_MAIN=com.vaticle.typedb.core.server.TypeDBServer
+        SERVER_DIR="${TYPEDB_HOME}/server"
+    else
+        TYPEDB_SERVER_NAME="TypeDB Cluster (Node)"
+        TYPEDB_SERVER_MAIN=com.vaticle.typedb.cluster.node.TypeDBNode
+        SERVER_DIR="${TYPEDB_HOME}/node"
+    fi
+    LIB_DIR="${SERVER_DIR}/lib"
+    CLASSPATH="${SERVER_DIR}/conf/:${LIB_DIR}/common/*"
+
+    if [[ -d "${SERVER_DIR}" ]]; then
         IDX=0
         while [[ "${@:IDX}" ]]; do
             case ${@:IDX:1} in
@@ -70,33 +83,33 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
             esac
             IDX=$((IDX+1))
         done
-        LIB_COMMON="server/lib/common/*"
-        CLASSPATH="${TYPEDB_HOME}/server/conf/:${TYPEDB_HOME}/${LIB_COMMON}"
+
         # exec replaces current shell process with java so no commands after these ones will ever get executed
         if [ $DEBUG ]; then
             case "$(uname -s)" in
-                Darwin) CLASSPATH="${CLASSPATH}:${TYPEDB_HOME}/server/lib/dev/*" ;;
+                Darwin) CLASSPATH="${CLASSPATH}:$LIB_DIR/dev/*" ;;
                 *) echo "WARNING: Debug mode RocksDB is not available in this platform. Fallback to production mode."
-                   CLASSPATH="${CLASSPATH}:${TYPEDB_HOME}/server/lib/prod/*" ;;
+                   CLASSPATH="${CLASSPATH}:$LIB_DIR/prod/*" ;;
             esac
-            exec $JAVA_BIN ${SERVER_JAVAOPTS} -ea -cp "${CLASSPATH}" \
+            exec $JAVA_BIN ${JAVAOPTS} -ea -cp "${CLASSPATH}" \
                 -Dtypedb.dir="${TYPEDB_HOME}" -Dtypedb.conf="${TYPEDB_HOME}/${TYPEDB_CONFIG}" \
                 -Dlogback.configurationFile=logback-debug.xml \
-                com.vaticle.typedb.core.server.TypeDBServer "${@:2}"
+                ${TYPEDB_SERVER_MAIN} "${@:2}"
         else
-            CLASSPATH="${CLASSPATH}:${TYPEDB_HOME}/server/lib/prod/*"
-            exec $JAVA_BIN ${SERVER_JAVAOPTS} -cp "${CLASSPATH}" \
+            CLASSPATH="${CLASSPATH}:$LIB_DIR/prod/*"
+            exec $JAVA_BIN ${JAVAOPTS} -cp "${CLASSPATH}" \
                 -Dtypedb.dir="${TYPEDB_HOME}" -Dtypedb.conf="${TYPEDB_HOME}/${TYPEDB_CONFIG}" \
-                com.vaticle.typedb.core.server.TypeDBServer "${@:2}"
+                ${TYPEDB_SERVER_MAIN} "${@:2}"
         fi
     else
-        echo "TypeDB Server is not included in this TypeDB distribution."
-        echo "You may want to install TypeDB Server or TypeDB (all)."
+        echo "$TYPEDB_SERVER_NAME is not included in this TypeDB distribution."
+        echo "You may want to install $TYPEDB_SERVER_NAME or TypeDB (all)."
         exit 1
     fi
 else
     echo "Invalid argument: $1. Possible commands are: "
     echo "  Server:          typedb server [--help]"
+    echo "  Node:            typedb node [--help]"
     echo "  Console:         typedb console [--help]"
     exit 1
 fi


### PR DESCRIPTION
## What is the goal of this PR?

We have added support for running a TypeDB Cluster node from the binary script:

```
$ ./typedb node
```

Additionally, we did a minor refactor simplifying how a user can specify `JAVAOPTS`:

```
JAVAOPTS=... ./typedb server
JAVAOPTS=... ./typedb node
JAVAOPTS=... ./typedb console
```

Last but not least, we fixed a bug where a user can execute an obsolete command `./typedb version`. The right command for checking the server version is `./typedb server --version`.

## What are the changes implemented in this PR?

1. Added support for running a TypeDB Cluster node
    - Make the logic for running Server and Node generic
    - Initialised Server and Node configurations with different value

2. Minor refactor: `CONSOLE_JAVAOPTS` and `SERVER_JAVAOPTS` environment variables have been renamed to `JAVAOPTS`.

3. Removed an obsolete command `./typedb version` which also behaved incorrectly: it runs the server.