### PR TITLE
Improve TypeDBRunner logs and assertions

### DIFF
--- a/test/server/TypeDBClusterRunner.java
+++ b/test/server/TypeDBClusterRunner.java
@@ -61,8 +61,8 @@ public class TypeDBClusterRunner extends TypeDBRunner {
 
     @Override
     public void start() {
-        assertFalse(name() + ": unable to start. Port " + ports.second() + " is still used.", isPortOpen(host(), ports.second()));
-        assertFalse(name() + ": unable to start. Port " + ports.third() + " is still used.", isPortOpen(host(), ports.third()));
+        if (isPortOpen(host(), ports.second())) throw new RuntimeException(name() + ": unable to start. Port " + ports.second() + " is still used.");
+        if (isPortOpen(host(), ports.third())) throw new RuntimeException(name() + ": unable to start. Port " + ports.third() + " is still used.");
         super.start();
     }
 

--- a/test/server/TypeDBClusterRunner.java
+++ b/test/server/TypeDBClusterRunner.java
@@ -60,8 +60,8 @@ public class TypeDBClusterRunner extends TypeDBRunner {
 
     @Override
     public void start() {
-        if (isPortOpen(host(), ports.second())) throw new RuntimeException(address() + ": unable to start. Port " + ports.second() + " is still used.");
-        if (isPortOpen(host(), ports.third())) throw new RuntimeException(address() + ": unable to start. Port " + ports.third() + " is still used.");
+        if (isPortOpen(host(), ports.second())) throw new RuntimeException(address() + ": unable to start. Port " + ports.second() + " is used by another process.");
+        if (isPortOpen(host(), ports.third())) throw new RuntimeException(address() + ": unable to start. Port " + ports.third() + " is used by another process.");
         super.start();
     }
 

--- a/test/server/TypeDBClusterRunner.java
+++ b/test/server/TypeDBClusterRunner.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeoutException;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.triple;
-import static org.junit.Assert.assertFalse;
 
 public class TypeDBClusterRunner extends TypeDBRunner {
 
@@ -51,7 +50,7 @@ public class TypeDBClusterRunner extends TypeDBRunner {
 
     @Override
     protected String name() {
-        return "TypeDB Cluster (" + address() + ")";
+        return "TypeDB Cluster";
     }
 
     @Override
@@ -61,8 +60,8 @@ public class TypeDBClusterRunner extends TypeDBRunner {
 
     @Override
     public void start() {
-        if (isPortOpen(host(), ports.second())) throw new RuntimeException(name() + ": unable to start. Port " + ports.second() + " is still used.");
-        if (isPortOpen(host(), ports.third())) throw new RuntimeException(name() + ": unable to start. Port " + ports.third() + " is still used.");
+        if (isPortOpen(host(), ports.second())) throw new RuntimeException(address() + ": unable to start. Port " + ports.second() + " is still used.");
+        if (isPortOpen(host(), ports.third())) throw new RuntimeException(address() + ": unable to start. Port " + ports.third() + " is still used.");
         super.start();
     }
 

--- a/test/server/TypeDBClusterRunner.java
+++ b/test/server/TypeDBClusterRunner.java
@@ -51,7 +51,7 @@ public class TypeDBClusterRunner extends TypeDBRunner {
 
     @Override
     protected String name() {
-        return "TypeDB Cluster";
+        return "TypeDB Cluster (" + address() + ")";
     }
 
     @Override
@@ -61,8 +61,8 @@ public class TypeDBClusterRunner extends TypeDBRunner {
 
     @Override
     public void start() {
-        assertFalse(isPortOpen(host(), ports.second()));
-        assertFalse(isPortOpen(host(), ports.third()));
+        assertFalse(name() + ": unable to start. Port " + ports.second() + " is still used.", isPortOpen(host(), ports.second()));
+        assertFalse(name() + ": unable to start. Port " + ports.third() + " is still used.", isPortOpen(host(), ports.third()));
         super.start();
     }
 

--- a/test/server/TypeDBClusterRunner.java
+++ b/test/server/TypeDBClusterRunner.java
@@ -60,8 +60,8 @@ public class TypeDBClusterRunner extends TypeDBRunner {
 
     @Override
     public void start() {
-        if (isPortOpen(host(), ports.second())) throw new RuntimeException(address() + ": unable to start. Port " + ports.second() + " is used by another process.");
-        if (isPortOpen(host(), ports.third())) throw new RuntimeException(address() + ": unable to start. Port " + ports.third() + " is used by another process.");
+        verifyPortUnused(ports.second());
+        verifyPortUnused(ports.third());
         super.start();
     }
 

--- a/test/server/TypeDBClusterRunner.java
+++ b/test/server/TypeDBClusterRunner.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeoutException;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.triple;
+import static org.junit.Assert.assertFalse;
 
 public class TypeDBClusterRunner extends TypeDBRunner {
 
@@ -59,22 +60,29 @@ public class TypeDBClusterRunner extends TypeDBRunner {
     }
 
     @Override
+    public void start() {
+        assertFalse(isPortOpen(host(), ports.second()));
+        assertFalse(isPortOpen(host(), ports.third()));
+        super.start();
+    }
+
+    @Override
     protected List<String> command() {
         List<String> command = new ArrayList<>();
         command.addAll(getTypeDBBinary());
         command.add("server");
         command.add("--address");
-        command.add(getAddressString(ports));
+        command.add(getAddressTripletString(ports));
         peerPorts.forEach(peerPort -> {
             command.add("--peer");
-            command.add(getAddressString(peerPort));
+            command.add(getAddressTripletString(peerPort));
         });
         command.add("--data");
         command.add(dataDir.toAbsolutePath().toString());
         return command;
     }
 
-    private String getAddressString(Triple<Integer, Integer, Integer> ports) {
-        return "127.0.0.1" + ":" + ports.first() + ":" + ports.second() + ":" + ports.third();
+    private String getAddressTripletString(Triple<Integer, Integer, Integer> ports) {
+        return host() + ":" + ports.first() + ":" + ports.second() + ":" + ports.third();
     }
 }

--- a/test/server/TypeDBCoreRunner.java
+++ b/test/server/TypeDBCoreRunner.java
@@ -40,7 +40,7 @@ public class TypeDBCoreRunner extends TypeDBRunner {
 
     @Override
     protected String name() {
-        return "TypeDB (core)";
+        return "TypeDB (" + address() + ")";
     }
 
     @Override

--- a/test/server/TypeDBCoreRunner.java
+++ b/test/server/TypeDBCoreRunner.java
@@ -40,7 +40,7 @@ public class TypeDBCoreRunner extends TypeDBRunner {
 
     @Override
     protected String name() {
-        return "TypeDB (" + address() + ")";
+        return "TypeDB Core";
     }
 
     @Override

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -69,7 +69,7 @@ public abstract class TypeDBRunner extends Runner {
     }
 
     public void start() {
-        if (isPortOpen(host(), port())) throw new RuntimeException(name() + ": unable to start. port " + port() + " is still used.");
+        if (isPortOpen(host(), port())) throw new RuntimeException(name() + ": unable to start. port " + port() + " is used by another process.");
         try {
             System.out.println(address() + ": starting... ");
             System.out.println(address() + ": distribution is located at " + rootPath.toAbsolutePath().toString());

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -19,6 +19,7 @@
 package com.vaticle.typedb.common.test.server;
 
 import com.vaticle.typedb.common.test.Runner;
+import org.zeroturnaround.exec.ProcessResult;
 import org.zeroturnaround.exec.StartedProcess;
 
 import java.io.BufferedReader;
@@ -79,10 +80,11 @@ public abstract class TypeDBRunner extends Runner {
             boolean started = checkServerStarted().await(SERVER_STARTUP_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             if (!started) {
                 String message = address() + ": unable to start. ";
-                if (!serverProcess.getFuture().isDone()) {
-                    message += address() + ": process exited with code '" + serverProcess.getProcess().exitValue() + "'. ";
-                    if (serverProcess.getFuture().get().hasOutput()) {
-                        message += "Output: " + serverProcess.getFuture().get().outputUTF8();
+                if (serverProcess.getFuture().isDone()) {
+                    ProcessResult processResult = serverProcess.getFuture().get();
+                    message += address() + ": process exited with code '" + processResult.getExitValue() + "'. ";
+                    if (processResult.hasOutput()) {
+                        message += "Output: " + processResult.outputUTF8();
                     }
                 }
                 throw new RuntimeException(message);

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -67,10 +67,18 @@ public abstract class TypeDBRunner extends Runner {
             System.out.println(displayName() + ": starting... ");
             System.out.println(displayName() + ": database server is located at " + rootPath.toAbsolutePath().toString());
             System.out.println(displayName() + ": database directory is located at " + dataDir.toAbsolutePath());
+            System.out.println(displayName() + ": command = " + command());
             serverProcess = executor.command(command()).start();
             boolean started = checkServerStarted().await(SERVER_STARTUP_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-            assertTrue(displayName() + " failed to start", started);
-            System.out.println(displayName() + " database server started");
+            if (!started) {
+                printLogs();
+                throw new RuntimeException(
+                        displayName() + " failed to start. " +
+                        "serverProcess.getProcess().isAlive(): " + serverProcess.getProcess().isAlive()
+                );
+            } else {
+                System.out.println(displayName() + " database server started");
+            }
         } catch (Throwable e) {
             printLogs();
             throw new RuntimeException(e);

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -71,16 +71,16 @@ public abstract class TypeDBRunner extends Runner {
     public void start() {
         if (isPortOpen(host(), port())) throw new RuntimeException(name() + ": unable to start. port " + port() + " is still used.");
         try {
-            System.out.println(name() + ": starting... ");
-            System.out.println(name() + ": distribution is located at " + rootPath.toAbsolutePath().toString());
-            System.out.println(name() + ": data directory is located at " + dataDir.toAbsolutePath());
-            System.out.println(name() + ": command = " + command());
+            System.out.println(address() + ": starting... ");
+            System.out.println(address() + ": distribution is located at " + rootPath.toAbsolutePath().toString());
+            System.out.println(address() + ": data directory is located at " + dataDir.toAbsolutePath());
+            System.out.println(address() + ": command = " + command());
             serverProcess = executor.command(command()).start();
             boolean started = checkServerStarted().await(SERVER_STARTUP_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             if (!started) {
-                throw new RuntimeException(name() + ": process exited with code '" + serverProcess.getProcess().exitValue() +"'.");
+                throw new RuntimeException(address() + ": process exited with code '" + serverProcess.getProcess().exitValue() +"'.");
             } else {
-                System.out.println(name() + ": started");
+                System.out.println(address() + ": started");
             }
         } catch (Throwable e) {
             printLogs();
@@ -99,7 +99,7 @@ public abstract class TypeDBRunner extends Runner {
                 retryNumber++;
                 if (retryNumber % 4 == 0) {
                     System.out.println(String.format("%s: waiting for server to start (%ds)...",
-                                                     name(), retryNumber * SERVER_ALIVE_POLL_INTERVAL_MILLIS / 1000));
+                                                     address(), retryNumber * SERVER_ALIVE_POLL_INTERVAL_MILLIS / 1000));
                 }
                 if (isPortOpen(host(), port())) {
                     latch.countDown();
@@ -124,9 +124,9 @@ public abstract class TypeDBRunner extends Runner {
     public void stop() {
         if (serverProcess != null) {
             try {
-                System.out.println(name() + ": stopping...");
+                System.out.println(address() + ": stopping...");
                 serverProcess.getProcess().destroyForcibly();
-                System.out.println(name() + ": stopped.");
+                System.out.println(address() + ": stopped.");
             } catch (Exception e) {
                 printLogs();
                 throw e;
@@ -136,13 +136,13 @@ public abstract class TypeDBRunner extends Runner {
 
     private void printLogs() {
         System.out.println("================");
-        System.out.println(name() + ": logs:");
+        System.out.println(address() + ": logs:");
         System.out.println("================");
         Path logPath = logsDir.resolve("typedb.log").toAbsolutePath();
         try {
             executor.command("cat", logPath.toString()).execute();
         } catch (IOException | InterruptedException | TimeoutException e) {
-            System.out.println(name() + ": unable to print '" + logPath + "'");
+            System.out.println(address() + ": unable to print '" + logPath + "'");
             e.printStackTrace();
         }
     }

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -42,11 +42,13 @@ public abstract class TypeDBRunner extends Runner {
     private static final int SERVER_ALIVE_POLL_MAX_RETRIES = SERVER_STARTUP_TIMEOUT_MILLIS / SERVER_ALIVE_POLL_INTERVAL_MILLIS;
 
     protected final Path dataDir;
+    protected final Path logsDir;
     private StartedProcess serverProcess;
 
     public TypeDBRunner() throws InterruptedException, TimeoutException, IOException {
         super();
         this.dataDir = rootPath.resolve("server").resolve("data");
+        this.logsDir = rootPath.resolve("server").resolve("logs");
     }
 
     protected abstract List<String> command();
@@ -126,7 +128,7 @@ public abstract class TypeDBRunner extends Runner {
         System.out.println("================");
         System.out.println(displayName() + " Logs:");
         System.out.println("================");
-        Path logPath = Paths.get(".", "logs", "typedb.log");
+        Path logPath = logsDir.resolve("typedb.log").toAbsolutePath();
         try {
             executor.command("cat", logPath.toString()).execute();
         } catch (IOException | InterruptedException | TimeoutException e) {

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -78,7 +78,8 @@ public abstract class TypeDBRunner extends Runner {
             serverProcess = executor.command(command()).start();
             boolean started = checkServerStarted().await(SERVER_STARTUP_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             if (!started) {
-                throw new RuntimeException(address() + ": process exited with code '" + serverProcess.getProcess().exitValue() +"'.");
+                if (!serverProcess.getProcess().isAlive())
+                    throw new RuntimeException(address() + ": process exited with code '" + serverProcess.getProcess().exitValue() +"'.");
             } else {
                 System.out.println(address() + ": started");
             }

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -73,8 +73,9 @@ public abstract class TypeDBRunner extends Runner {
             if (!started) {
                 printLogs();
                 throw new RuntimeException(
-                        displayName() + " failed to start. " +
-                        "serverProcess.getProcess().isAlive(): " + serverProcess.getProcess().isAlive()
+                        displayName() + ": process exited with code '" + serverProcess.getProcess().exitValue() +"'. " +
+                                "stdout = '" + serverProcess.getProcess().getOutputStream().toString() + "'. " +
+                                "stderr = '" + serverProcess.getProcess().getErrorStream().toString() + "'"
                 );
             } else {
                 System.out.println(displayName() + " database server started");
@@ -97,13 +98,6 @@ public abstract class TypeDBRunner extends Runner {
                 if (retryNumber % 4 == 0) {
                     System.out.println(String.format("%s: waiting for server to start (%ds)...",
                                                      displayName(), retryNumber * SERVER_ALIVE_POLL_INTERVAL_MILLIS / 1000));
-                }
-                if (!serverProcess.getProcess().isAlive()) {
-                    throw new RuntimeException(
-                            displayName() + ": process exited with code '" + serverProcess.getProcess().exitValue() +"'. " +
-                                    "stdout = '" + serverProcess.getProcess().getOutputStream().toString() + "'. " +
-                                    "stderr = '" + serverProcess.getProcess().getErrorStream().toString() + "'"
-                    );
                 }
                 if (isPortOpen("localhost", port())) {
                     latch.countDown();

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -78,8 +78,14 @@ public abstract class TypeDBRunner extends Runner {
             serverProcess = executor.command(command()).start();
             boolean started = checkServerStarted().await(SERVER_STARTUP_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             if (!started) {
-                if (!serverProcess.getProcess().isAlive())
-                    throw new RuntimeException(address() + ": process exited with code '" + serverProcess.getProcess().exitValue() +"'.");
+                String message = address() + ": unable to start. ";
+                if (!serverProcess.getFuture().isDone()) {
+                    message += address() + ": process exited with code '" + serverProcess.getProcess().exitValue() + "'. ";
+                    if (serverProcess.getFuture().get().hasOutput()) {
+                        message += "Output: " + serverProcess.getFuture().get().outputUTF8();
+                    }
+                }
+                throw new RuntimeException(message);
             } else {
                 System.out.println(address() + ": started");
             }

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -21,9 +21,13 @@ package com.vaticle.typedb.common.test.server;
 import com.vaticle.typedb.common.test.Runner;
 import org.zeroturnaround.exec.StartedProcess;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Timer;
@@ -31,6 +35,7 @@ import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertTrue;
 
@@ -74,8 +79,8 @@ public abstract class TypeDBRunner extends Runner {
                 printLogs();
                 throw new RuntimeException(
                         displayName() + ": process exited with code '" + serverProcess.getProcess().exitValue() +"'. " +
-                                "stdout = '" + serverProcess.getProcess().getOutputStream().toString() + "'. " +
-                                "stderr = '" + serverProcess.getProcess().getErrorStream().toString() + "'"
+                                "stdout = '" + read(serverProcess.getProcess().getInputStream()) + "'. " +
+                                "stderr = '" + read(serverProcess.getProcess().getErrorStream()) + "'"
                 );
             } else {
                 System.out.println(displayName() + " database server started");
@@ -150,5 +155,11 @@ public abstract class TypeDBRunner extends Runner {
         String[] args = System.getProperty("sun.java.command").split(" ");
         assert args.length > 1;
         return new File(args[1]);
+    }
+
+    private static String read(InputStream inputStream) {
+        return new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+                .lines()
+                .collect(Collectors.joining("\n"));
     }
 }

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -22,13 +22,9 @@ import com.vaticle.typedb.common.test.Runner;
 import org.zeroturnaround.exec.ProcessResult;
 import org.zeroturnaround.exec.StartedProcess;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.Socket;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Timer;
@@ -36,10 +32,6 @@ import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public abstract class TypeDBRunner extends Runner {
 

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class TypeDBRunner extends Runner {
 
-    private static final int SERVER_STARTUP_TIMEOUT_MILLIS = 30000;
+    private static final int SERVER_STARTUP_TIMEOUT_MILLIS = 300000;
     private static final int SERVER_ALIVE_POLL_INTERVAL_MILLIS = 500;
     private static final int SERVER_ALIVE_POLL_MAX_RETRIES = SERVER_STARTUP_TIMEOUT_MILLIS / SERVER_ALIVE_POLL_INTERVAL_MILLIS;
 

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class TypeDBRunner extends Runner {
 
-    private static final int SERVER_STARTUP_TIMEOUT_MILLIS = 300000;
+    private static final int SERVER_STARTUP_TIMEOUT_MILLIS = 30000;
     private static final int SERVER_ALIVE_POLL_INTERVAL_MILLIS = 500;
     private static final int SERVER_ALIVE_POLL_MAX_RETRIES = SERVER_STARTUP_TIMEOUT_MILLIS / SERVER_ALIVE_POLL_INTERVAL_MILLIS;
 

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -69,8 +69,8 @@ public abstract class TypeDBRunner extends Runner {
     }
 
     public void start() {
+        if (isPortOpen(host(), port())) throw new RuntimeException(name() + ": unable to start. port " + port() + " is still used.");
         try {
-            assertFalse(name() + ": unable to start. port " + port() + " is still used.", isPortOpen(host(), port()));
             System.out.println(name() + ": starting... ");
             System.out.println(name() + ": distribution is located at " + rootPath.toAbsolutePath().toString());
             System.out.println(name() + ": data directory is located at " + dataDir.toAbsolutePath());

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -69,7 +69,7 @@ public abstract class TypeDBRunner extends Runner {
     }
 
     public void start() {
-        if (isPortOpen(host(), port())) throw new RuntimeException(name() + ": unable to start. port " + port() + " is used by another process.");
+        verifyPortUnused(port());
         try {
             System.out.println(address() + ": starting... ");
             System.out.println(address() + ": distribution is located at " + rootPath.toAbsolutePath().toString());
@@ -112,16 +112,6 @@ public abstract class TypeDBRunner extends Runner {
         return latch;
     }
 
-    protected static boolean isPortOpen(String host, int port) {
-        try {
-            Socket s = new Socket(host, port);
-            s.close();
-            return true;
-        } catch (IOException e) {
-            return false;
-        }
-    }
-
     public void stop() {
         if (serverProcess != null) {
             try {
@@ -153,5 +143,19 @@ public abstract class TypeDBRunner extends Runner {
         String[] args = System.getProperty("sun.java.command").split(" ");
         assert args.length > 1;
         return new File(args[1]);
+    }
+
+    protected void verifyPortUnused(int port) {
+        if (isPortOpen(host(), port)) throw new RuntimeException(name() + ": unable to start. port " + port + " is used by another process.");
+    }
+
+    protected static boolean isPortOpen(String host, int port) {
+        try {
+            Socket s = new Socket(host, port);
+            s.close();
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
     }
 }

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -91,7 +90,14 @@ public abstract class TypeDBRunner extends Runner {
                     System.out.println(String.format("%s: waiting for server to start (%ds)...",
                                                      displayName(), retryNumber * SERVER_ALIVE_POLL_INTERVAL_MILLIS / 1000));
                 }
-                if (isServerReady("localhost", port())) {
+                if (!serverProcess.getProcess().isAlive()) {
+                    throw new RuntimeException(
+                            displayName() + ": process exited with code '" + serverProcess.getProcess().exitValue() +"'. " +
+                                    "stdout = '" + serverProcess.getProcess().getOutputStream().toString() + "'. " +
+                                    "stderr = '" + serverProcess.getProcess().getErrorStream().toString() + "'"
+                    );
+                }
+                if (isPortOpen("localhost", port())) {
                     latch.countDown();
                     timer.cancel();
                 }
@@ -101,7 +107,7 @@ public abstract class TypeDBRunner extends Runner {
         return latch;
     }
 
-    private static boolean isServerReady(String host, int port) {
+    private static boolean isPortOpen(String host, int port) {
         try {
             Socket s = new Socket(host, port);
             s.close();


### PR DESCRIPTION
## What is the goal of this PR?

We've improved TypeDBRunner logs and assertions, in order to provide a better troubleshooting / debugging experience for developers.

## What are the changes implemented in this PR?

- TypeDBRunner instance will first check if the ports are used before starting
- TypeDBRunner instance will print the address in the logs whenever possible. This is especially useful in TypeDBClusterRunner where there may be multiple instances running at the same time.
- Fix a bug where the log file isn't displayed due to using an incorrect relative path