### PR TITLE
Supports running TypeDB Cluster

### DIFF
--- a/binary/typedb
+++ b/binary/typedb
@@ -66,7 +66,7 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "cluster" ]]; then
         TYPEDB_SERVER_NAME="TypeDB (Server)"
         TYPEDB_SERVER_CLASS=com.vaticle.typedb.core.server.TypeDBServer
 
-        if [[ -d "server/replication" ]]; then
+        if [[ ! -f "server/resources/typedb-ascii.txt" ]]; then
             echo "$TYPEDB_SERVER_NAME is not found. Make sure to install or download $TYPEDB_SERVER_NAME or $TYPEDB_ALL_NAME."
             exit 1
         fi
@@ -75,7 +75,7 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "cluster" ]]; then
         TYPEDB_SERVER_NAME="TypeDB Cluster (Server)"
         TYPEDB_SERVER_CLASS=com.vaticle.typedb.cluster.server.TypeDBClusterServer
 
-        if [[ ! -d "server/replication" ]]; then
+        if [[ ! -f "server/resources/typedb-cluster-ascii.txt" ]]; then
             echo "$TYPEDB_SERVER_NAME is not found. Make sure to install or download $TYPEDB_SERVER_NAME or $TYPEDB_ALL_NAME."
             exit 1
         fi

--- a/binary/typedb
+++ b/binary/typedb
@@ -65,50 +65,55 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "cluster" ]]; then
         TYPEDB_ALL_NAME="TypeDB (All)"
         TYPEDB_SERVER_NAME="TypeDB (Server)"
         TYPEDB_SERVER_CLASS=com.vaticle.typedb.core.server.TypeDBServer
+
+        if [[ -d "server/replication" ]]; then
+            echo "$TYPEDB_SERVER_NAME is not found. Make sure to install or download $TYPEDB_SERVER_NAME or $TYPEDB_ALL_NAME."
+            exit 1
+        fi
     else
         TYPEDB_ALL_NAME="TypeDB Cluster (All)"
         TYPEDB_SERVER_NAME="TypeDB Cluster (Server)"
         TYPEDB_SERVER_CLASS=com.vaticle.typedb.cluster.server.TypeDBClusterServer
+
+        if [[ ! -d "server/replication" ]]; then
+            echo "$TYPEDB_SERVER_NAME is not found. Make sure to install or download $TYPEDB_SERVER_NAME or $TYPEDB_ALL_NAME."
+            exit 1
+        fi
     fi
     TYPEDB_SERVER_DIR="${TYPEDB_HOME}/server"
     TYPEDB_SERVER_LIB_DIR="${TYPEDB_SERVER_DIR}/lib"
     CLASSPATH="${TYPEDB_SERVER_DIR}/conf/:${TYPEDB_SERVER_LIB_DIR}/common/*"
 
-    if [[ -d "${TYPEDB_SERVER_DIR}" ]]; then
-        IDX=0
-        while [[ "${@:IDX}" ]]; do
-            case ${@:IDX:1} in
-                --debug) DEBUG=yes;
-                break;
-            esac
-            IDX=$((IDX+1))
-        done
+    IDX=0
+    while [[ "${@:IDX}" ]]; do
+        case ${@:IDX:1} in
+            --debug) DEBUG=yes;
+            break;
+        esac
+        IDX=$((IDX+1))
+    done
 
-        # exec replaces current shell process with java so no commands after these ones will ever get executed
-        if [ $DEBUG ]; then
-            case "$(uname -s)" in
-                Darwin) CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/dev/*" ;;
-                *) echo "WARNING: Debug mode RocksDB is not available in this platform. Fallback to production mode."
-                   CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/prod/*" ;;
-            esac
-            exec $JAVA_BIN ${JAVAOPTS} -ea -cp "${CLASSPATH}" \
-                -Dtypedb.dir="${TYPEDB_HOME}" -Dtypedb.conf="${TYPEDB_HOME}/${TYPEDB_CONFIG}" \
-                -Dlogback.configurationFile=logback-debug.xml \
-                ${TYPEDB_SERVER_CLASS} "${@:2}"
-        else
-            CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/prod/*"
-            exec $JAVA_BIN ${JAVAOPTS} -cp "${CLASSPATH}" \
-                -Dtypedb.dir="${TYPEDB_HOME}" -Dtypedb.conf="${TYPEDB_HOME}/${TYPEDB_CONFIG}" \
-                ${TYPEDB_SERVER_CLASS} "${@:2}"
-        fi
+    # exec replaces current shell process with java so no commands after these ones will ever get executed
+    if [ $DEBUG ]; then
+        case "$(uname -s)" in
+            Darwin) CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/dev/*" ;;
+            *) echo "WARNING: Debug mode RocksDB is not available in this platform. Fallback to production mode."
+               CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/prod/*" ;;
+        esac
+        exec $JAVA_BIN ${JAVAOPTS} -ea -cp "${CLASSPATH}" \
+            -Dtypedb.dir="${TYPEDB_HOME}" -Dtypedb.conf="${TYPEDB_HOME}/${TYPEDB_CONFIG}" \
+            -Dlogback.configurationFile=logback-debug.xml \
+            ${TYPEDB_SERVER_CLASS} "${@:2}"
     else
-        echo "$TYPEDB_SERVER_NAME is not found. Make sure to install or download $TYPEDB_SERVER_NAME or $TYPEDB_ALL_NAME."
-        exit 1
+        CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/prod/*"
+        exec $JAVA_BIN ${JAVAOPTS} -cp "${CLASSPATH}" \
+            -Dtypedb.dir="${TYPEDB_HOME}" -Dtypedb.conf="${TYPEDB_HOME}/${TYPEDB_CONFIG}" \
+            ${TYPEDB_SERVER_CLASS} "${@:2}"
     fi
 else
     echo "Invalid argument: $1. Possible commands are: "
     echo "  Server:          typedb server [--help]"
-    echo "  Cluster:            typedb cluster [--help]"
+    echo "  Cluster:         typedb cluster [--help]"
     echo "  Console:         typedb console [--help]"
     exit 1
 fi


### PR DESCRIPTION
## What is the goal of this PR?

We've added the support for running TypeBD and TypeDB Cluster using the command `./typedb server` and `./typedb cluster`, respectively.

## What are the changes implemented in this PR?

1. Add the command `./typedb cluster` and additionally adds a check which throws an error, if executed on a TypeDB instead of a TypeDB Cluster distribution
2. Adds a check to the `./typedb server`, which throws an error if executed on a TypeDB Cluster instead of TypeDB distribution