### PR TITLE
'typedb.bat' for TypeDB Cluster

### DIFF
--- a/binary/typedb.bat
+++ b/binary/typedb.bat
@@ -85,7 +85,7 @@ if exist .\server\ (
   goto exit
 ) else (
   echo TypeDB Cluster is not included in this TypeDB distribution^.
-  echo You may want to install TypeDB Cluster or TypeDB ^(all^)^.
+  echo You may want to install TypeDB Cluster or TypeDB Cluster ^(all^)^.
   goto exiterror
 )
 

--- a/binary/typedb.bat
+++ b/binary/typedb.bat
@@ -32,12 +32,12 @@ if %ERRORLEVEL% GEQ 1 (
 if "%1" == "" goto missingargument
 
 if "%1" == "console" goto startconsole
-
+if "%1" == "cluster" goto startcluster
 if "%1" == "server"  goto startserver
-if "%1" == "version" goto startserver
 
 echo   Invalid argument: %1. Possible commands are:
 echo   Server:          typedb server [--help]
+echo   Cluster:         typedb cluster [--help]
 echo   Console:         typedb console [--help]
 goto exiterror
 
@@ -45,6 +45,7 @@ goto exiterror
 
  echo   Missing argument. Possible commands are:
  echo   Server:          typedb server [--help]
+ echo   Cluster:         typedb cluster [--help]
  echo   Console:         typedb console [--help]
 
 goto exiterror
@@ -74,6 +75,20 @@ if exist .\server\ (
   echo You may want to install TypeDB Server or TypeDB ^(all^)^.
   goto exiterror
 )
+
+:startcluster
+
+set "G_CP=%TYPEDB_HOME%\server\conf\;%TYPEDB_HOME%\server\lib\common\*;%TYPEDB_HOME%\server\lib\prod\*"
+
+if exist .\server\ (
+  java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" -Dtypedb.conf="%TYPEDB_HOME%\%TYPEDB_CONFIG%" com.vaticle.typedb.cluster.server.TypeDBClusterServer %2 %3 %4 %5 %6 %7 %8 %9
+  goto exit
+) else (
+  echo TypeDB Cluster is not included in this TypeDB distribution^.
+  echo You may want to install TypeDB Cluster or TypeDB ^(all^)^.
+  goto exiterror
+)
+
 
 :exit
 exit /b 0


### PR DESCRIPTION
## What is the goal of this PR?

User can now boot up TypeDB Cluster on Windows with `./typedb.bat cluster`

## What are the changes implemented in this PR?

Handle `cluster` argument in `typedb.bat`

Fix #111 