### PR TITLE
Upgrade Java dependency for APT package

### DIFF
--- a/binary/BUILD
+++ b/binary/BUILD
@@ -60,7 +60,7 @@ assemble_apt(
         "var/log/typedb/",
     ],
     depends = [
-        "openjdk-8-jre"
+        "openjdk-11-jre"
     ],
     permissions = {
         "var/log/typedb/": "0777",


### PR DESCRIPTION
## What is the goal of this PR?

Depend on Java 11 in APT package for consistency with TypeDB Server

## What are the changes implemented in this PR?

Depend on `openjdk-11-jre` for APT installations.