### PR TITLE
Fix APT package deployment

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -68,6 +68,12 @@ build:
       command: |
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
+        # Downgrading Python is needed to work around bazelbuild/rules_pkg#397
+        pyenv install 3.7.9
+        pyenv global 3.7.9
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
         bazel run --define version=$(git rev-parse HEAD) //binary:deploy-apt -- snapshot
 release:
   filter:
@@ -98,4 +104,10 @@ release:
         cat VERSION
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
+        # Downgrading Python is needed to work around bazelbuild/rules_pkg#397
+        pyenv install 3.7.9
+        pyenv global 3.7.9
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
         bazel run --define version=$(cat VERSION) //binary:deploy-apt -- release

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,5 +21,5 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "905ddac41fa327965f045db29b5f860a18eeca42", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "4ee548cea883c716055566847c4736a7ef791c38", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )


### PR DESCRIPTION
## What is the goal of this PR?

Make APT package that we deploy installable again

## What are the changes implemented in this PR?

Use Python 3.7 version to run `deploy-apt-*` jobs to avoid bazelbuild/rules_pkg#397