### PR TITLE
Make yaml wrapper class mutable

### DIFF
--- a/yaml/Yaml.java
+++ b/yaml/Yaml.java
@@ -46,7 +46,8 @@ public interface Yaml {
     }
 
     default Map asMap() {
-        throw new ClassCastException();
+        throw new ClassCastException(String.format("Illegal cast from '%s' to '%s'.", className(getClass()),
+                className(Map.class)));
     }
 
     default boolean isList() {
@@ -54,7 +55,8 @@ public interface Yaml {
     }
 
     default List asList() {
-        throw new ClassCastException();
+        throw new ClassCastException(String.format("Illegal cast from '%s' to '%s'.", className(getClass()),
+                className(List.class)));
     }
 
     default boolean isPrimitive() {
@@ -62,7 +64,8 @@ public interface Yaml {
     }
 
     default Primitive asPrimitive() {
-        throw new ClassCastException();
+        throw new ClassCastException(String.format("Illegal cast from '%s' to '%s'.", className(getClass()),
+                className(Primitive.class)));
     }
 
     class Map extends java.util.LinkedHashMap<String, Yaml> implements Yaml {
@@ -115,12 +118,11 @@ public interface Yaml {
             this.object = object;
         }
 
-        public static Primitive wrap(Object object) {
-            if (!(object instanceof String || object instanceof Integer || object instanceof Float ||
-                    object instanceof Boolean)) {
-                throw new ClassCastException();
+        public static Primitive wrap(Object obj) {
+            if (!(obj instanceof String || obj instanceof Integer || obj instanceof Float || obj instanceof Boolean)) {
+                throw new ClassCastException("Type '" + className(obj.getClass()) + "' is not a known yaml primitive.");
             }
-            return new Primitive(object);
+            return new Primitive(obj);
         }
 
         @Override
@@ -138,6 +140,10 @@ public interface Yaml {
         }
 
         public String asString() {
+            if (!isString()) {
+                throw new ClassCastException(String.format("Illegal cast from '%s' to '%s'.",
+                        className(getClass()), className(String.class)));
+            }
             return (String) object;
         }
 
@@ -146,6 +152,10 @@ public interface Yaml {
         }
 
         public int asInt() {
+            if (!isInt()) {
+                throw new ClassCastException(String.format("Illegal cast from '%s' to '%s'.",
+                        className(getClass()), className(Integer.class)));
+            }
             return (Integer) object;
         }
 
@@ -154,6 +164,10 @@ public interface Yaml {
         }
 
         public float asFloat() {
+            if (!isFloat()) {
+                throw new ClassCastException(String.format("Illegal cast from '%s' to '%s'.", className(getClass()),
+                        className(Float.class)));
+            }
             return (Float) object;
         }
 
@@ -162,6 +176,10 @@ public interface Yaml {
         }
 
         public boolean asBoolean() {
+            if (!isBoolean()) {
+                throw new ClassCastException(String.format("Illegal cast from '%s' to '%s'.", className(getClass()),
+                        className(Boolean.class)));
+            }
             return (Boolean) object;
         }
 

--- a/yaml/Yaml.java
+++ b/yaml/Yaml.java
@@ -109,7 +109,7 @@ public abstract class Yaml {
 
         private final java.util.Map<java.lang.String, Yaml> map;
 
-        private Map(java.util.Map<java.lang.String, Yaml> map) {
+        public Map(java.util.Map<java.lang.String, Yaml> map) {
             this.map = map;
         }
 

--- a/yaml/Yaml.java
+++ b/yaml/Yaml.java
@@ -26,19 +26,19 @@ import static com.vaticle.typedb.common.util.Objects.className;
 
 public interface Yaml {
 
-    static Yaml create(String yaml) {
+    static Yaml load(String yaml) {
         return wrap(new org.yaml.snakeyaml.Yaml().load(yaml));
     }
 
-    static Yaml create(Path filePath) throws FileNotFoundException {
+    static Yaml load(Path filePath) throws FileNotFoundException {
         FileInputStream inputStream = new FileInputStream(filePath.toFile());
         return wrap(new org.yaml.snakeyaml.Yaml().load(inputStream));
     }
 
-    static Yaml wrap(Object parsedYaml) {
-        if (parsedYaml instanceof java.util.Map) return Map.create((java.util.Map<String, Object>) parsedYaml);
-        else if (parsedYaml instanceof java.util.List) return List.create((java.util.List<Object>) parsedYaml);
-        else return Primitive.create(parsedYaml);
+    static Yaml wrap(Object yamlCompatible) {
+        if (yamlCompatible instanceof java.util.Map) return Map.wrap((java.util.Map<String, Object>) yamlCompatible);
+        else if (yamlCompatible instanceof java.util.List) return List.wrap((java.util.List<Object>) yamlCompatible);
+        else return Primitive.wrap(yamlCompatible);
     }
 
     default boolean isMap() {
@@ -67,7 +67,7 @@ public interface Yaml {
 
     class Map extends java.util.LinkedHashMap<String, Yaml> implements Yaml {
 
-        static Map create(java.util.Map<String, Object> map) {
+        static Map wrap(java.util.Map<String, Object> map) {
             Map mapYaml = new Map();
             for (String key : map.keySet()) {
                 mapYaml.put(key, Yaml.wrap(map.get(key)));
@@ -88,7 +88,7 @@ public interface Yaml {
 
     class List extends ArrayList<Yaml> implements Yaml {
 
-        static List create(java.util.List<Object> list) {
+        static List wrap(java.util.List<Object> list) {
             List listYaml = new List();
             for (Object e : list) {
                 listYaml.add(Yaml.wrap(e));
@@ -115,9 +115,11 @@ public interface Yaml {
             this.object = object;
         }
 
-        public static Primitive create(Object object) {
-            assert object instanceof String || object instanceof Integer || object instanceof Float ||
-                    object instanceof Boolean;
+        public static Primitive wrap(Object object) {
+            if (!(object instanceof String || object instanceof Integer || object instanceof Float ||
+                    object instanceof Boolean)) {
+                throw new ClassCastException();
+            }
             return new Primitive(object);
         }
 

--- a/yaml/Yaml.java
+++ b/yaml/Yaml.java
@@ -22,6 +22,8 @@ import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 
+import static com.vaticle.typedb.common.util.Objects.className;
+
 public interface Yaml {
 
     static Yaml create(String yaml) {
@@ -113,10 +115,20 @@ public interface Yaml {
             this.object = object;
         }
 
-        static Primitive create(Object object) {
+        public static Primitive create(Object object) {
             assert object instanceof String || object instanceof Integer || object instanceof Float ||
                     object instanceof Boolean;
             return new Primitive(object);
+        }
+
+        @Override
+        public boolean isPrimitive() {
+            return true;
+        }
+
+        @Override
+        public Primitive asPrimitive() {
+            return this;
         }
 
         public boolean isString() {
@@ -149,6 +161,11 @@ public interface Yaml {
 
         public boolean asBoolean() {
             return (Boolean) object;
+        }
+
+        @Override
+        public String toString() {
+            return object + "[" + className(object.getClass()) + "]";
         }
     }
 }

--- a/yaml/Yaml.java
+++ b/yaml/Yaml.java
@@ -45,9 +45,9 @@ public abstract class Yaml {
             return Map.wrap((java.util.Map<java.lang.String, Object>) yaml);
         } else if (yaml instanceof java.util.List) return List.wrap((java.util.List<Object>) yaml);
         else if (yaml instanceof java.lang.String) return new String((java.lang.String) yaml);
-        else if (yaml instanceof java.lang.Integer) return new Int((java.lang.Integer) yaml);
-        else if (yaml instanceof java.lang.Float) return new Float((java.lang.Float) yaml);
-        else if (yaml instanceof java.lang.Boolean) return new Boolean((java.lang.Boolean) yaml);
+        else if (yaml instanceof java.lang.Integer) return new Int((int) yaml);
+        else if (yaml instanceof java.lang.Float) return new Float((float) yaml);
+        else if (yaml instanceof java.lang.Boolean) return new Boolean((boolean) yaml);
         else throw new IllegalStateException();
     }
 

--- a/yaml/Yaml.java
+++ b/yaml/Yaml.java
@@ -21,7 +21,10 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.Set;
+import java.util.function.BiConsumer;
 
 import static com.vaticle.typedb.common.util.Objects.className;
 
@@ -118,6 +121,26 @@ public abstract class Yaml {
             return new Map(map);
         }
 
+        public boolean containsKey(java.lang.String key) {
+            return map.containsKey(key);
+        }
+
+        public Set<java.lang.String> keys() {
+            return map.keySet();
+        }
+
+        public Yaml get(java.lang.String key) {
+            return map.get(key);
+        }
+
+        public void put(java.lang.String key, Yaml value) {
+            map.put(key, value);
+        }
+
+        public void forEach(BiConsumer<java.lang.String, Yaml> consumer) {
+            map.forEach(consumer);
+        }
+
         @Override
         public boolean isMap() {
             return true;
@@ -145,6 +168,10 @@ public abstract class Yaml {
             return new List(yamlList);
         }
 
+        public Iterator<Yaml> iterator() {
+            return list.iterator();
+        }
+
         @Override
         public boolean isList() {
             return true;
@@ -156,7 +183,7 @@ public abstract class Yaml {
         }
     }
 
-    static class String extends Yaml {
+    public static class String extends Yaml {
 
         private final java.lang.String value;
 
@@ -184,7 +211,7 @@ public abstract class Yaml {
         }
     }
 
-    static class Int extends Yaml {
+    public static class Int extends Yaml {
 
         private final int value;
 
@@ -196,10 +223,12 @@ public abstract class Yaml {
             return value;
         }
 
+        @Override
         public boolean isInt() {
             return true;
         }
 
+        @Override
         public Int asInt() {
             return this;
         }
@@ -222,10 +251,12 @@ public abstract class Yaml {
             return value;
         }
 
+        @Override
         public boolean isFloat() {
             return true;
         }
 
+        @Override
         public Float asFloat() {
             return this;
         }
@@ -248,10 +279,12 @@ public abstract class Yaml {
             return value;
         }
 
+        @Override
         public boolean isBoolean() {
             return true;
         }
 
+        @Override
         public Boolean asBoolean() {
             return this;
         }

--- a/yaml/Yaml.java
+++ b/yaml/Yaml.java
@@ -56,8 +56,7 @@ public abstract class Yaml {
     }
 
     public Map asMap() {
-        throw new ClassCastException(java.lang.String.format("Illegal cast from '%s' to '%s'.", className(getClass()),
-                className(Map.class)));
+        throw classCastException(getClass(), Map.class);
     }
 
     public boolean isList() {
@@ -65,8 +64,7 @@ public abstract class Yaml {
     }
 
     public List asList() {
-        throw new ClassCastException(java.lang.String.format("Illegal cast from '%s' to '%s'.", className(getClass()),
-                className(List.class)));
+        throw classCastException(getClass(), List.class);
     }
 
     public boolean isString() {
@@ -74,8 +72,7 @@ public abstract class Yaml {
     }
 
     public String asString() {
-        throw new ClassCastException(java.lang.String.format("Illegal cast from '%s' to '%s'.", className(getClass()),
-                className(String.class)));
+        throw classCastException(getClass(), String.class);
     }
 
     public boolean isInt() {
@@ -83,8 +80,7 @@ public abstract class Yaml {
     }
 
     public Int asInt() {
-        throw new ClassCastException(java.lang.String.format("Illegal cast from '%s' to '%s'.", className(getClass()),
-                className(Int.class)));
+        throw classCastException(getClass(), Int.class);
     }
 
     public boolean isFloat() {
@@ -92,8 +88,7 @@ public abstract class Yaml {
     }
 
     public Float asFloat() {
-        throw new ClassCastException(java.lang.String.format("Illegal cast from '%s' to '%s'.", className(getClass()),
-                className(Float.class)));
+        throw classCastException(getClass(), Float.class);
     }
 
     public boolean isBoolean() {
@@ -101,8 +96,12 @@ public abstract class Yaml {
     }
 
     public Boolean asBoolean() {
-        throw new ClassCastException(java.lang.String.format("Illegal cast from '%s' to '%s'.", className(getClass()),
-                className(Boolean.class)));
+        throw classCastException(getClass(), Boolean.class);
+    }
+
+    private ClassCastException classCastException(Class<?> from, Class<?> to) {
+        return new ClassCastException(java.lang.String.format("Illegal cast from '%s' to '%s'.", className(from),
+                className(to)));
     }
 
     public static class Map extends Yaml {


### PR DESCRIPTION
## What is the goal of this PR?

To be able to append to and update a YAML object, we modify our wrapper Yaml class to allow mutations. This effectively copies a `Yaml` object that Snakeyaml loads, into native Java objects.

## What are the changes implemented in this PR?

* Specialise the types in the Yaml wrapper to be either Map, List, or primitives String, Float, Int, or Boolean
* Allow loading a Yaml string or file with the new top-level API: `load`