### PR TITLE
Remove logback or typedb.properties references from binaries

### DIFF
--- a/binary/typedb
+++ b/binary/typedb
@@ -23,7 +23,6 @@ if [[ ! -z "$JAVA_HOME" ]]; then
 fi
 [[ $(readlink $0) ]] && path=$(readlink $0) || path=$0
 TYPEDB_HOME=$(cd "$(dirname "${path}")" && pwd -P)
-TYPEDB_CONFIG="server/conf/typedb.properties"
 
 # ================================================
 # common helper functions
@@ -104,14 +103,11 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "cluster" ]]; then
             *) echo "WARNING: Debug mode RocksDB is not available in this platform. Fallback to production mode."
                CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/prod/*" ;;
         esac
-        exec $JAVA_BIN ${JAVAOPTS} -ea -cp "${CLASSPATH}" \
-            -Dtypedb.dir="${TYPEDB_HOME}" -Dtypedb.conf="${TYPEDB_HOME}/${TYPEDB_CONFIG}" \
-            -Dlogback.configurationFile=logback-debug.xml \
+        exec $JAVA_BIN ${JAVAOPTS} -ea -cp "${CLASSPATH}" \ -Dtypedb.dir="${TYPEDB_HOME}" \
             ${TYPEDB_SERVER_CLASS} "${@:2}"
     else
         CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/prod/*"
-        exec $JAVA_BIN ${JAVAOPTS} -cp "${CLASSPATH}" \
-            -Dtypedb.dir="${TYPEDB_HOME}" -Dtypedb.conf="${TYPEDB_HOME}/${TYPEDB_CONFIG}" \
+        exec $JAVA_BIN ${JAVAOPTS} -cp "${CLASSPATH}" \ -Dtypedb.dir="${TYPEDB_HOME}" - \
             ${TYPEDB_SERVER_CLASS} "${@:2}"
     fi
 else

--- a/binary/typedb.bat
+++ b/binary/typedb.bat
@@ -18,8 +18,6 @@ REM
 SET "TYPEDB_HOME=%cd%"
 
 
-SET "TYPEDB_CONFIG=server\conf\typedb.properties"
-
 where java >NUL 2>NUL
 if %ERRORLEVEL% GEQ 1 (
     echo Java is not installed on this machine.
@@ -68,7 +66,7 @@ set "G_CP=%TYPEDB_HOME%\server\conf\;%TYPEDB_HOME%\server\lib\common\*;%TYPEDB_H
 
 
 if exist .\server\ (
-  java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" -Dtypedb.conf="%TYPEDB_HOME%\%TYPEDB_CONFIG%" com.vaticle.typedb.core.server.TypeDBServer %2 %3 %4 %5 %6 %7 %8 %9
+  java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.core.server.TypeDBServer %2 %3 %4 %5 %6 %7 %8 %9
   goto exit
 ) else (
   echo TypeDB Server is not included in this TypeDB distribution^.
@@ -81,7 +79,7 @@ if exist .\server\ (
 set "G_CP=%TYPEDB_HOME%\server\conf\;%TYPEDB_HOME%\server\lib\common\*;%TYPEDB_HOME%\server\lib\prod\*"
 
 if exist .\server\ (
-  java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" -Dtypedb.conf="%TYPEDB_HOME%\%TYPEDB_CONFIG%" com.vaticle.typedb.cluster.server.TypeDBClusterServer %2 %3 %4 %5 %6 %7 %8 %9
+  java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.cluster.server.TypeDBClusterServer %2 %3 %4 %5 %6 %7 %8 %9
   goto exit
 ) else (
   echo TypeDB Cluster is not included in this TypeDB distribution^.


### PR DESCRIPTION
## What is the goal of this PR?

As of https://github.com/vaticle/typedb/pull/6473 we no longer use a properties file or logback file, since everything is handled in the server. We can remove references to either of these from the bat and bash runner scripts.

## What are the changes implemented in this PR?

* Remove references to Logback and Properties files in bat and bash script