### PR TITLE
Throw if given null values in yaml lists or maps

### DIFF
--- a/yaml/Yaml.java
+++ b/yaml/Yaml.java
@@ -115,6 +115,9 @@ public abstract class Yaml {
         private static Map wrap(java.util.Map<java.lang.String, Object> source) {
             java.util.Map<java.lang.String, Yaml> map = new LinkedHashMap<>();
             for (java.lang.String key : source.keySet()) {
+                if (source.get(key) == null) {
+                    throw new IllegalArgumentException("Illegal null value for key: " + key + ".");
+                }
                 map.put(key, Yaml.wrap(source.get(key)));
             }
             return new Map(map);

--- a/yaml/Yaml.java
+++ b/yaml/Yaml.java
@@ -165,6 +165,9 @@ public abstract class Yaml {
         static List wrap(java.util.List<Object> source) {
             java.util.List<Yaml> yamlList = new ArrayList<>();
             for (Object e : source) {
+                if (e == null) {
+                    throw new IllegalArgumentException("Illegal null value encountered in list.");
+                }
                 yamlList.add(Yaml.wrap(e));
             }
             return new List(yamlList);


### PR DESCRIPTION
## What is the goal of this PR?

We find and protect against a previously illegal state, where the value of a Yaml map or a list element is null. We now throw an explicit exception when this scenario is encountered.

## What are the changes implemented in this PR?

* Throw meaningful error message if given a null value in a yaml map or yaml list