### PR TITLE
Use new core argument format for core runner

### DIFF
--- a/test/server/TypeDBCoreRunner.java
+++ b/test/server/TypeDBCoreRunner.java
@@ -48,9 +48,9 @@ public class TypeDBCoreRunner extends TypeDBRunner {
         List<String> command = new ArrayList<>();
         command.addAll(getTypeDBBinary());
         command.add("server");
-        command.add("--port");
-        command.add(Integer.toString(port));
-        command.add("--data");
+        command.add("--server.address");
+        command.add("0.0.0.0:" + port);
+        command.add("--storage.data");
         command.add(dataDir.toAbsolutePath().toString());
         return command;
     }


### PR DESCRIPTION
## What is the goal of this PR?

We fix assembly tests in TypeDB by updating the core runner to use the new arguments required by TypeDB. 

## What are the changes implemented in this PR?
- change `--port` to `--server.address`, and `--data` to `--storage.data`