### PR TITLE
Make test runner support the latest TypeDB Cluster

### DIFF
--- a/test/Runner.java
+++ b/test/Runner.java
@@ -49,7 +49,7 @@ public abstract class Runner {
             throw new IllegalArgumentException("TypeDB distribution file is missing from " + distributionArchive.getAbsolutePath());
         }
 
-        checkAndDeleteExistingDistribution(distributionArchive);
+        checkAndDeleteExistingDistribution();
 
         String distributionArchiveFormat = distributionFormat(distributionArchive);
         Path distributionDir = distributionTarget();
@@ -62,6 +62,10 @@ public abstract class Runner {
         rootPath = distributionSetup(distributionDir, distributionArchiveFormat, distributionArchive);
         System.out.println(name() + " runner constructed");
     }
+
+    protected abstract String name();
+
+    protected abstract File distributionArchive();
 
     private String distributionFormat(File distributionFile) {
         if (distributionFile.toString().endsWith(TAR_GZ)) {
@@ -78,9 +82,9 @@ public abstract class Runner {
         return Files.createTempDirectory("typedb");
     }
 
-    private void checkAndDeleteExistingDistribution(File distributionFile) throws IOException {
+    private void checkAndDeleteExistingDistribution() throws IOException {
         Path target = distributionTarget();
-        System.out.println("Checking for existing distribution at " + target.toAbsolutePath().toString());
+        System.out.println("Checking for existing distribution at " + target.toAbsolutePath());
         if (target.toFile().exists()) {
             System.out.println("An existing distribution found. Deleting...");
             FileUtils.deleteDirectory(target.toFile());
@@ -111,8 +115,4 @@ public abstract class Runner {
     protected List<String> getTypeDBBinary() {
         return System.getProperty("os.name").toLowerCase().contains("win") ? Arrays.asList("cmd.exe", "/c", "typedb.bat") : Collections.singletonList("typedb");
     }
-
-    protected abstract File distributionArchive();
-
-    protected abstract String name();
 }

--- a/test/server/TypeDBClusterRunner.java
+++ b/test/server/TypeDBClusterRunner.java
@@ -18,7 +18,6 @@
 
 package com.vaticle.typedb.common.test.server;
 
-import javax.sound.sampled.Port;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -117,8 +116,8 @@ public class TypeDBClusterRunner extends TypeDBRunner {
     @Override
     protected List<String> command() {
         Map<String, String> options = new HashMap<>();
-        addOptions(options, server);
-        addOptions(options, peers);
+        options.putAll(serverOptions(server));
+        options.putAll(peerOptions(peers));
         options.putAll(remainingOptions);
 
         List<String> command = new ArrayList<>();
@@ -128,13 +127,16 @@ public class TypeDBClusterRunner extends TypeDBRunner {
         return command;
     }
 
-    private static void addOptions(Map<String, String> options, Ports serverPorts) {
+    private static Map<String, String> serverOptions(Ports serverPorts) {
+        Map<String, String> options = new HashMap<>();
         options.put(OPT_ADDR, host() + ":" + serverPorts.port());
         options.put(OPT_INTERNAL_ADDR_ZMQ, host() + ":" + serverPorts.internalZMQ());
         options.put(OPT_INTERNAL_ADDR_GRPC, host() + ":" + serverPorts.internalGRPC());
+        return options;
     }
 
-    private static void addOptions(Map<String, String> options, Set<Ports> peerPorts) {
+    private static Map<String, String> peerOptions(Set<Ports> peerPorts) {
+        Map<String, String> options = new HashMap<>();
         int index = 0;
         for (Ports peer: peerPorts) {
             String addrKey = OPT_PEERS_ADDR.replace("{index}", "" + index);
@@ -145,6 +147,7 @@ public class TypeDBClusterRunner extends TypeDBRunner {
             options.put(intlAddrGRPCKey, host() + ":" + peer.internalGRPC());
             index++;
         }
+        return options;
     }
 
     public static class Ports {
@@ -152,6 +155,7 @@ public class TypeDBClusterRunner extends TypeDBRunner {
 
         private final int internalZMQ;
         private final int internalGRPC;
+
         public Ports(int port, int internalZMQ, int internalGRPC) {
             this.port = port;
             this.internalZMQ = internalZMQ;

--- a/test/server/TypeDBClusterRunner.java
+++ b/test/server/TypeDBClusterRunner.java
@@ -33,10 +33,10 @@ import static com.vaticle.typedb.common.collection.Collections.set;
 
 public class TypeDBClusterRunner extends TypeDBRunner {
 
-    public static final String OPT_ADDR = "--server.address";
+    private static final String OPT_ADDR = "--server.address";
     private static final String OPT_INTERNAL_ADDR_ZMQ = "--server.internal-address.zeromq";
     private static final String OPT_INTERNAL_ADDR_GRPC = "--server.internal-address.grpc";
-    public static final String OPT_PEERS_ADDR = "--server.peers.server-{peer-id}.address";
+    private static final String OPT_PEERS_ADDR = "--server.peers.server-{peer-id}.address";
     private static final String OPT_PEERS_INTERNAL_ADDR_ZMQ = "--server.peers.server-{peer-id}.internal-address.zeromq";
     private static final String OPT_PEERS_INTERNAL_ADDR_GRPC = "--server.peers.server-{peer-id}.internal-address.grpc";
 
@@ -47,23 +47,23 @@ public class TypeDBClusterRunner extends TypeDBRunner {
     public static TypeDBClusterRunner create() throws InterruptedException, TimeoutException, IOException {
         int port = ThreadLocalRandom.current().nextInt(40000, 60000);
         Ports server = new Ports(port, port+1, port+2);
-        return TypeDBClusterRunner.create(server);
+        return create(server);
     }
 
     public static TypeDBClusterRunner create(Map<String, String> remainingServerOpts)
             throws IOException, InterruptedException, TimeoutException {
         int port = ThreadLocalRandom.current().nextInt(40000, 60000);
         Ports server = new Ports(port, port+1, port+2);
-        return TypeDBClusterRunner.create(server, remainingServerOpts);
+        return create(server, remainingServerOpts);
     }
 
     public static TypeDBClusterRunner create(Ports ports) throws IOException, InterruptedException, TimeoutException {
-        return TypeDBClusterRunner.create(ports, set());
+        return create(ports, set());
     }
 
     public static TypeDBClusterRunner create(Ports ports, Set<Ports> peers)
             throws IOException, InterruptedException, TimeoutException {
-        return TypeDBClusterRunner.create(ports, peers, map());
+        return create(ports, peers, map());
     }
 
     public static TypeDBClusterRunner create(Ports ports, Map<String, String> remainingServerOpts)
@@ -108,9 +108,9 @@ public class TypeDBClusterRunner extends TypeDBRunner {
 
     @Override
     protected void verifyPortUnused() {
-        super.verifyPortUnused(port());
-        super.verifyPortUnused(ports().internalZMQ());
-        super.verifyPortUnused(ports().internalGRPC());
+        verifyPortUnused(port());
+        verifyPortUnused(ports().internalZMQ());
+        verifyPortUnused(ports().internalGRPC());
     }
 
     @Override
@@ -151,8 +151,8 @@ public class TypeDBClusterRunner extends TypeDBRunner {
     }
 
     public static class Ports {
-        private final int external;
 
+        private final int external;
         private final int internalZMQ;
         private final int internalGRPC;
 

--- a/test/server/TypeDBClusterRunner.java
+++ b/test/server/TypeDBClusterRunner.java
@@ -36,9 +36,9 @@ public class TypeDBClusterRunner extends TypeDBRunner {
     private static final String OPT_ADDR = "--server.address";
     private static final String OPT_INTERNAL_ADDR_ZMQ = "--server.internal-address.zeromq";
     private static final String OPT_INTERNAL_ADDR_GRPC = "--server.internal-address.grpc";
-    private static final String OPT_PEERS_ADDR = "--server.peers.server-{peer-id}.address";
-    private static final String OPT_PEERS_INTERNAL_ADDR_ZMQ = "--server.peers.server-{peer-id}.internal-address.zeromq";
-    private static final String OPT_PEERS_INTERNAL_ADDR_GRPC = "--server.peers.server-{peer-id}.internal-address.grpc";
+    private static final String OPT_PEERS_ADDR = "--server.peers.server-peer-%d.address";
+    private static final String OPT_PEERS_INTERNAL_ADDR_ZMQ = "--server.peers.server-peer-%d.internal-address.zeromq";
+    private static final String OPT_PEERS_INTERNAL_ADDR_GRPC = "--server.peers.server-peer-%d.internal-address.grpc";
 
     private final Ports ports;
     private final Set<Ports> peers;
@@ -139,9 +139,9 @@ public class TypeDBClusterRunner extends TypeDBRunner {
         Map<String, String> options = new HashMap<>();
         int index = 0;
         for (Ports peer: peers) {
-            String addrKey = OPT_PEERS_ADDR.replace("{peer-id}", "peer-" + index);
-            String intAddrZMQKey = OPT_PEERS_INTERNAL_ADDR_ZMQ.replace("{peer-id}", "peer-" + index);
-            String intlAddrGRPCKey = OPT_PEERS_INTERNAL_ADDR_GRPC.replace("{peer-id}", "peer-" + index);
+            String addrKey = String.format(OPT_PEERS_ADDR, index);
+            String intAddrZMQKey = String.format(OPT_PEERS_INTERNAL_ADDR_ZMQ, index);
+            String intlAddrGRPCKey = String.format(OPT_PEERS_INTERNAL_ADDR_GRPC, index);
             options.put(addrKey, host() + ":" + peer.external());
             options.put(intAddrZMQKey, host() + ":" + peer.internalZMQ());
             options.put(intlAddrGRPCKey, host() + ":" + peer.internalGRPC());

--- a/test/server/TypeDBCoreRunner.java
+++ b/test/server/TypeDBCoreRunner.java
@@ -34,13 +34,18 @@ public class TypeDBCoreRunner extends TypeDBRunner {
     }
 
     @Override
+    protected String name() {
+        return "TypeDB Core";
+    }
+
+    @Override
     protected int port() {
         return port;
     }
 
     @Override
-    protected String name() {
-        return "TypeDB Core";
+    protected void verifyPortUnused() {
+        verifyPortUnused(port());
     }
 
     @Override

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -49,7 +49,18 @@ public abstract class TypeDBRunner extends Runner {
         this.logsDir = rootPath.resolve("server").resolve("logs");
     }
 
+    @Override
+    protected File distributionArchive() {
+        String[] args = System.getProperty("sun.java.command").split(" ");
+        assert args.length > 1;
+        return new File(args[1]);
+    }
+
     protected abstract List<String> command();
+
+    public String address() {
+        return host() + ":" + port();
+    }
 
     protected static String host() {
         return "127.0.0.1";
@@ -57,8 +68,20 @@ public abstract class TypeDBRunner extends Runner {
 
     protected abstract int port();
 
-    public String address() {
-        return host() + ":" + port();
+    protected abstract void verifyPortUnused();
+
+    protected void verifyPortUnused(int port) {
+        if (isPortOpen(host(), port)) throw new RuntimeException(name() + ": unable to start. port " + port + " is used by another process.");
+    }
+
+    protected static boolean isPortOpen(String host, int port) {
+        try {
+            Socket s = new Socket(host, port);
+            s.close();
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     public void start() {
@@ -135,31 +158,6 @@ public abstract class TypeDBRunner extends Runner {
         } catch (IOException | InterruptedException | TimeoutException e) {
             System.out.println(address() + ": unable to print '" + logPath + "'");
             e.printStackTrace();
-        }
-    }
-
-    @Override
-    protected File distributionArchive() {
-        String[] args = System.getProperty("sun.java.command").split(" ");
-        assert args.length > 1;
-        return new File(args[1]);
-    }
-
-    protected void verifyPortUnused() {
-        verifyPortUnused(port());
-    }
-
-    protected void verifyPortUnused(int port) {
-        if (isPortOpen(host(), port)) throw new RuntimeException(name() + ": unable to start. port " + port + " is used by another process.");
-    }
-
-    protected static boolean isPortOpen(String host, int port) {
-        try {
-            Socket s = new Socket(host, port);
-            s.close();
-            return true;
-        } catch (IOException e) {
-            return false;
         }
     }
 }

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -51,7 +51,7 @@ public abstract class TypeDBRunner extends Runner {
 
     protected abstract List<String> command();
 
-    protected String host() {
+    protected static String host() {
         return "127.0.0.1";
     }
 
@@ -62,10 +62,10 @@ public abstract class TypeDBRunner extends Runner {
     }
 
     public void start() {
-        verifyPortUnused(port());
+        verifyPortUnused();
         try {
             System.out.println(address() + ": starting... ");
-            System.out.println(address() + ": distribution is located at " + rootPath.toAbsolutePath().toString());
+            System.out.println(address() + ": distribution is located at " + rootPath.toAbsolutePath());
             System.out.println(address() + ": data directory is located at " + dataDir.toAbsolutePath());
             System.out.println(address() + ": command = " + command());
             serverProcess = executor.command(command()).start();
@@ -143,6 +143,10 @@ public abstract class TypeDBRunner extends Runner {
         String[] args = System.getProperty("sun.java.command").split(" ");
         assert args.length > 1;
         return new File(args[1]);
+    }
+
+    protected void verifyPortUnused() {
+        verifyPortUnused(port());
     }
 
     protected void verifyPortUnused(int port) {


### PR DESCRIPTION
## What is the goal of this PR?

The Cluster test runner supports the latest version of TypeDB Cluster.

Additionally, the runner can be configured more flexibly, allowing for any server parameters to be overridden.

## What are the changes implemented in this PR?

1. Support the latest TypeDB Cluster by updating how the runner boots up the server.
2. Make configuring the runner more flexible by introducing additional factory method variants.