### PR TITLE
TypeDB runner allocates unused ports

### DIFF
--- a/test/server/TypeDBClusterRunner.java
+++ b/test/server/TypeDBClusterRunner.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 
 import static com.vaticle.typedb.common.collection.Collections.map;
@@ -45,15 +44,15 @@ public class TypeDBClusterRunner extends TypeDBRunner {
     private final Map<String, String> remainingServerOpts;
 
     public static TypeDBClusterRunner create() throws InterruptedException, TimeoutException, IOException {
-        int port = ThreadLocalRandom.current().nextInt(40000, 60000);
-        Ports server = new Ports(port, port+1, port+2);
+        List<Integer> ports = findUnusedPorts(3);
+        Ports server = new Ports(ports.get(0), ports.get(1), ports.get(2));
         return create(server);
     }
 
     public static TypeDBClusterRunner create(Map<String, String> remainingServerOpts)
             throws IOException, InterruptedException, TimeoutException {
-        int port = ThreadLocalRandom.current().nextInt(40000, 60000);
-        Ports server = new Ports(port, port+1, port+2);
+        List<Integer> ports = findUnusedPorts(3);
+        Ports server = new Ports(ports.get(0), ports.get(1), ports.get(2));
         return create(server, remainingServerOpts);
     }
 
@@ -107,13 +106,6 @@ public class TypeDBClusterRunner extends TypeDBRunner {
     }
 
     @Override
-    protected void verifyPortUnused() {
-        verifyPortUnused(port());
-        verifyPortUnused(ports().internalZMQ());
-        verifyPortUnused(ports().internalGRPC());
-    }
-
-    @Override
     protected List<String> command() {
         Map<String, String> serverOpts = new HashMap<>();
         serverOpts.putAll(portOptions(ports));
@@ -138,7 +130,7 @@ public class TypeDBClusterRunner extends TypeDBRunner {
     private static Map<String, String> peerOptions(Set<Ports> peers) {
         Map<String, String> options = new HashMap<>();
         int index = 0;
-        for (Ports peer: peers) {
+        for (Ports peer : peers) {
             String addrKey = String.format(OPT_PEERS_ADDR, index);
             String intAddrZMQKey = String.format(OPT_PEERS_INTERNAL_ADDR_ZMQ, index);
             String intlAddrGRPCKey = String.format(OPT_PEERS_INTERNAL_ADDR_GRPC, index);

--- a/test/server/TypeDBCoreRunner.java
+++ b/test/server/TypeDBCoreRunner.java
@@ -21,7 +21,6 @@ package com.vaticle.typedb.common.test.server;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 
 public class TypeDBCoreRunner extends TypeDBRunner {
@@ -30,7 +29,7 @@ public class TypeDBCoreRunner extends TypeDBRunner {
 
     public TypeDBCoreRunner() throws InterruptedException, TimeoutException, IOException {
         super();
-        this.port = ThreadLocalRandom.current().nextInt(40000, 60000);
+        this.port = findUnusedPorts(1).get(0);
     }
 
     @Override
@@ -41,11 +40,6 @@ public class TypeDBCoreRunner extends TypeDBRunner {
     @Override
     protected int port() {
         return port;
-    }
-
-    @Override
-    protected void verifyPortUnused() {
-        verifyPortUnused(port());
     }
 
     @Override

--- a/test/server/TypeDBCoreRunner.java
+++ b/test/server/TypeDBCoreRunner.java
@@ -48,7 +48,7 @@ public class TypeDBCoreRunner extends TypeDBRunner {
         command.addAll(getTypeDBBinary());
         command.add("server");
         command.add("--server.address");
-        command.add("0.0.0.0:" + port);
+        command.add(address());
         command.add("--storage.data");
         command.add(dataDir.toAbsolutePath().toString());
         return command;

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -39,6 +39,7 @@ public abstract class TypeDBRunner extends Runner {
 
     private static final int SERVER_STARTUP_TIMEOUT_MILLIS = 30000;
     private static final int SERVER_ALIVE_POLL_INTERVAL_MILLIS = 500;
+    private static final int PORT_ALLOCATION_RETRIES = 15;
     private static final int SERVER_ALIVE_POLL_MAX_RETRIES = SERVER_STARTUP_TIMEOUT_MILLIS / SERVER_ALIVE_POLL_INTERVAL_MILLIS;
 
     protected final Path dataDir;
@@ -73,7 +74,7 @@ public abstract class TypeDBRunner extends Runner {
     protected static List<Integer> findUnusedPorts(int count) {
         assert count > 0;
         try {
-            while (true) {
+            for (int retries = 0; retries < PORT_ALLOCATION_RETRIES; retries++) {
                 List<Integer> ports = new ArrayList<>(count);
                 // using port 0 automatically allocates a valid free port
                 ServerSocket seed = new ServerSocket(0);
@@ -88,6 +89,7 @@ public abstract class TypeDBRunner extends Runner {
                 }
                 if (ports.size() == count) return ports;
             }
+            throw new RuntimeException("Failed to allocate ports within  " + PORT_ALLOCATION_RETRIES + " retries");
         } catch (IOException e) {
             throw new RuntimeException("Error while searching for unused port.");
         }

--- a/test/server/TypeDBRunner.java
+++ b/test/server/TypeDBRunner.java
@@ -39,7 +39,7 @@ public abstract class TypeDBRunner extends Runner {
 
     private static final int SERVER_STARTUP_TIMEOUT_MILLIS = 30000;
     private static final int SERVER_ALIVE_POLL_INTERVAL_MILLIS = 500;
-    private static final int PORT_ALLOCATION_RETRIES = 15;
+    private static final int PORT_ALLOCATION_MAX_RETRIES = 15;
     private static final int SERVER_ALIVE_POLL_MAX_RETRIES = SERVER_STARTUP_TIMEOUT_MILLIS / SERVER_ALIVE_POLL_INTERVAL_MILLIS;
 
     protected final Path dataDir;
@@ -74,7 +74,7 @@ public abstract class TypeDBRunner extends Runner {
     protected static List<Integer> findUnusedPorts(int count) {
         assert count > 0;
         try {
-            for (int retries = 0; retries < PORT_ALLOCATION_RETRIES; retries++) {
+            for (int retries = 0; retries < PORT_ALLOCATION_MAX_RETRIES; retries++) {
                 List<Integer> ports = new ArrayList<>(count);
                 // using port 0 automatically allocates a valid free port
                 ServerSocket seed = new ServerSocket(0);
@@ -89,7 +89,7 @@ public abstract class TypeDBRunner extends Runner {
                 }
                 if (ports.size() == count) return ports;
             }
-            throw new RuntimeException("Failed to allocate ports within  " + PORT_ALLOCATION_RETRIES + " retries");
+            throw new RuntimeException("Failed to allocate ports within  " + PORT_ALLOCATION_MAX_RETRIES + " retries");
         } catch (IOException e) {
             throw new RuntimeException("Error while searching for unused port.");
         }


### PR DESCRIPTION
## What is the goal of this PR?

TypeDB runner will find an unused port to boot up with to guarantee a successful bootup. In the previous approach, a random integer was chosen which could sometimes happen to be a reserved or in-use port and would cause an error when booting the server.

## What are the changes implemented in this PR?

* replace the mechanism for choosing a port for a Core or Cluster server to boot up with:
  * first, find an unused port that is not clashing and available for use
  * then use this port to initialise the database
* previously, a random number was chosen that could represent a reserved/used port, cause the bootup to fail at a later stage.
* refactor the server-avaibility polling to improve readability