### PR TITLE
Fix runner archive extraction error

### DIFF
--- a/test/Util.java
+++ b/test/Util.java
@@ -54,7 +54,7 @@ public class Util {
 
     public static File getArchivePath(int index) {
         String[] args = System.getProperty("sun.java.command").split(" ");
-        if (args.length <= index) {
+        if (index >= args.length) {
             throw new IllegalArgumentException("Distribution archive at index '" + index + "' is not defined");
         }
         File file = new File(args[index]);

--- a/test/Util.java
+++ b/test/Util.java
@@ -54,7 +54,7 @@ public class Util {
 
     public static File getArchivePath(int index) {
         String[] args = System.getProperty("sun.java.command").split(" ");
-        if (args.length < index) {
+        if (args.length <= index) {
             throw new IllegalArgumentException("Distribution archive at index '" + index + "' is not defined");
         }
         File file = new File(args[index]);


### PR DESCRIPTION
## What is the goal of this PR?

TypeDB Runner now handles unarchiving artifacts in a more rigorous way with respect to the provided indices. Now, we correctly check that a provided index is valid prior to an array lookup.

## What are the changes implemented in this PR?

Prior to unarchiving a runner we need to get its path from the arguments passed to the JVM. We want to ensure that index is strictly less than args.length so that
```java
File file = new File(args[index]);
```
is valid.

We check if index is equal to args.length as well as greater than, as both will lead to the `args[index]` call to fail.
