### PR TITLE
Refactor runner, adding support for kotlin

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -23,6 +23,7 @@ java_library(
     deps = [
         "//:common",
         "@maven//:commons_io_commons_io",
+        "@maven//:info_picocli_picocli",
         "@maven//:junit_junit",
         "@maven//:org_zeroturnaround_zt_exec",
         "@maven//:org_slf4j_slf4j_api"

--- a/test/Util.java
+++ b/test/Util.java
@@ -53,20 +53,24 @@ public class Util {
     private static final int SERVER_ALIVE_POLL_INTERVAL_MILLIS = 500;
     private static final int SERVER_ALIVE_POLL_MAX_RETRIES = SERVER_STARTUP_TIMEOUT_MILLIS / SERVER_ALIVE_POLL_INTERVAL_MILLIS;
 
-    public static File getArchivePath(String flag) {
+    public static File getServerArchiveFile() {
         String[] args = System.getProperty("sun.java.command").split(" ");
         Optional<CLIOptions> maybeOptions = CLIOptions.parseCLIOptions(args);
         if (!maybeOptions.isPresent()) {
             throw new IllegalArgumentException("No archives were passed as arguments");
         }
         CLIOptions options = maybeOptions.get();
-        if (flag.equals("--server")) {
-            return new File(options.getServerArchive());
+        return new File(options.getServerArchive());
+    }
+
+    public static File getConsoleArchiveFile() {
+        String[] args = System.getProperty("sun.java.command").split(" ");
+        Optional<CLIOptions> maybeOptions = CLIOptions.parseCLIOptions(args);
+        if (!maybeOptions.isPresent()) {
+            throw new IllegalArgumentException("No archives were passed as arguments");
         }
-        if (flag.equals("--console")) {
-            return new File(options.getConsoleArchive());
-        }
-        throw new IllegalArgumentException("Unrecognised arguments");
+        CLIOptions options = maybeOptions.get();
+        return new File(options.getConsoleArchive());
     }
 
     public static Path unarchive(File archive) throws IOException, TimeoutException, InterruptedException {

--- a/test/Util.java
+++ b/test/Util.java
@@ -204,20 +204,19 @@ public class Util {
                 .readOutput(true)
                 .destroyOnExit();
     }
-}
 
     @CommandLine.Command(name = "java")
-    class CLIOptions {
+    private static class CLIOptions {
         @CommandLine.Parameters String mainClass;
         @CommandLine.Option(
-            names = {"--server"},
-            description = "Location of the archive containing a server artifact."
+                names = {"--server"},
+                description = "Location of the archive containing a server artifact."
         )
         private String serverArchive;
 
         @CommandLine.Option(
-            names = {"--console"},
-            description = "Location of the archive containing a console artifact."
+                names = {"--console"},
+                description = "Location of the archive containing a console artifact."
         )
         private String consoleArchive;
 
@@ -251,3 +250,6 @@ public class Util {
             }
         }
     }
+}
+
+

--- a/test/Util.java
+++ b/test/Util.java
@@ -55,11 +55,11 @@ public class Util {
 
     public static File getArchivePath(String flag) {
         String[] args = System.getProperty("sun.java.command").split(" ");
-        Optional maybeOptions = CLIOptions.parseCLIOptions(args);
+        Optional<CLIOptions> maybeOptions = CLIOptions.parseCLIOptions(args);
         if (!maybeOptions.isPresent()) {
             throw new IllegalArgumentException("No archives were passed as arguments");
         }
-        CLIOptions options = (CLIOptions) maybeOptions.get();
+        CLIOptions options = maybeOptions.get();
         if (flag.equals("--server")) {
             return new File(options.getServerArchive());
         }
@@ -232,15 +232,7 @@ public class Util {
             CommandLine commandLine = new CommandLine(new CLIOptions());
             try {
                 CommandLine.ParseResult result = commandLine.parseArgs(args);
-                if (commandLine.isUsageHelpRequested()) {
-                    commandLine.usage(commandLine.getOut());
-                    return Optional.empty();
-                } else if (commandLine.isVersionHelpRequested()) {
-                    commandLine.printVersionHelp(commandLine.getOut());
-                    return Optional.empty();
-                } else {
-                    return Optional.of(result.asCommandLineList().get(0).getCommand());
-                }
+                return Optional.of(result.asCommandLineList().get(0).getCommand());
             } catch (CommandLine.ParameterException ex) {
                 commandLine.getErr().println(ex.getMessage());
                 if (!CommandLine.UnmatchedArgumentException.printSuggestions(ex, commandLine.getErr())) {

--- a/test/cluster/TypeDBClusterServerRunner.java
+++ b/test/cluster/TypeDBClusterServerRunner.java
@@ -34,7 +34,7 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
 import static com.vaticle.typedb.common.test.Util.createProcessExecutor;
-import static com.vaticle.typedb.common.test.Util.getArchivePath;
+import static com.vaticle.typedb.common.test.Util.getServerArchiveFile;
 import static com.vaticle.typedb.common.test.Util.unarchive;
 
 public interface TypeDBClusterServerRunner extends TypeDBRunner {
@@ -54,14 +54,13 @@ public interface TypeDBClusterServerRunner extends TypeDBRunner {
 
     class Standalone implements TypeDBClusterServerRunner {
 
-        private static final String FLAG = "--server";
         protected final Path distribution;
         protected final Map<String, String> serverOptions;
         private StartedProcess process;
         protected ProcessExecutor executor;
 
         public Standalone(Map<String, String> serverOptions) throws IOException, InterruptedException, TimeoutException {
-            distribution = unarchive(getArchivePath(FLAG));
+            distribution = unarchive(getServerArchiveFile());
             this.serverOptions = serverOptions;
             System.out.println(addresses() + ": " + name() + " constructing runner...");
             Files.createDirectories(ClusterServerOpts.storageData(serverOptions));

--- a/test/cluster/TypeDBClusterServerRunner.java
+++ b/test/cluster/TypeDBClusterServerRunner.java
@@ -54,15 +54,14 @@ public interface TypeDBClusterServerRunner extends TypeDBRunner {
 
     class Standalone implements TypeDBClusterServerRunner {
 
-        private static final int ARCHIVE_INDEX = 1;
-
+        private static final String FLAG = "--server";
         protected final Path distribution;
         protected final Map<String, String> serverOptions;
         private StartedProcess process;
         protected ProcessExecutor executor;
 
         public Standalone(Map<String, String> serverOptions) throws IOException, InterruptedException, TimeoutException {
-            distribution = unarchive(getArchivePath(ARCHIVE_INDEX));
+            distribution = unarchive(getArchivePath(FLAG));
             this.serverOptions = serverOptions;
             System.out.println(addresses() + ": " + name() + " constructing runner...");
             Files.createDirectories(ClusterServerOpts.storageData(serverOptions));

--- a/test/console/TypeDBConsoleRunner.java
+++ b/test/console/TypeDBConsoleRunner.java
@@ -28,19 +28,18 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
-import static com.vaticle.typedb.common.test.Util.getArchivePath;
+import static com.vaticle.typedb.common.test.Util.getConsoleArchiveFile;
 import static com.vaticle.typedb.common.test.Util.unarchive;
 
 public class TypeDBConsoleRunner {
 
-    private static final String FLAG = "--console";
     protected final Path distribution;
     protected ProcessExecutor executor;
 
     public TypeDBConsoleRunner() throws InterruptedException, TimeoutException, IOException {
         System.out.println("Constructing " + name() + " runner");
         System.out.println("Extracting " + name() + " distribution archive.");
-        distribution = unarchive(getArchivePath(FLAG));
+        distribution = unarchive(getConsoleArchiveFile());
         System.out.println(name() + " distribution archive extracted.");
         executor = new ProcessExecutor()
                 .directory(distribution.toFile())

--- a/test/console/TypeDBConsoleRunner.java
+++ b/test/console/TypeDBConsoleRunner.java
@@ -33,15 +33,14 @@ import static com.vaticle.typedb.common.test.Util.unarchive;
 
 public class TypeDBConsoleRunner {
 
-    private static final int ARCHIVE_INDEX = 2;
-
+    private static final String FLAG = "--console";
     protected final Path distribution;
     protected ProcessExecutor executor;
 
     public TypeDBConsoleRunner() throws InterruptedException, TimeoutException, IOException {
         System.out.println("Constructing " + name() + " runner");
         System.out.println("Extracting " + name() + " distribution archive.");
-        distribution = unarchive(getArchivePath(ARCHIVE_INDEX));
+        distribution = unarchive(getArchivePath(FLAG));
         System.out.println(name() + " distribution archive extracted.");
         executor = new ProcessExecutor()
                 .directory(distribution.toFile())

--- a/test/core/TypeDBCoreRunner.java
+++ b/test/core/TypeDBCoreRunner.java
@@ -31,13 +31,11 @@ import java.util.concurrent.TimeoutException;
 
 import static com.vaticle.typedb.common.test.Util.createProcessExecutor;
 import static com.vaticle.typedb.common.test.Util.findUnusedPorts;
-import static com.vaticle.typedb.common.test.Util.getArchivePath;
+import static com.vaticle.typedb.common.test.Util.getServerArchiveFile;
 import static com.vaticle.typedb.common.test.Util.typeDBCommand;
 import static com.vaticle.typedb.common.test.Util.unarchive;
 
 public class TypeDBCoreRunner implements TypeDBRunner {
-
-    private static final String FLAG = "--server";
 
     private final Path distribution;
     private final Path dataDir;
@@ -50,7 +48,7 @@ public class TypeDBCoreRunner implements TypeDBRunner {
         port = findUnusedPorts(1).get(0);
         System.out.println(address() + ": Constructing " + name() + " runner");
         System.out.println(address() + ": Extracting distribution archive...");
-        distribution = unarchive(getArchivePath(FLAG));
+        distribution = unarchive(getServerArchiveFile());
         System.out.println(address() + ": Distribution archive extracted.");
         dataDir = distribution.resolve("server").resolve("data");
         logsDir = distribution.resolve("server").resolve("logs");

--- a/test/core/TypeDBCoreRunner.java
+++ b/test/core/TypeDBCoreRunner.java
@@ -37,7 +37,7 @@ import static com.vaticle.typedb.common.test.Util.unarchive;
 
 public class TypeDBCoreRunner implements TypeDBRunner {
 
-    private static final int ARCHIVE_INDEX = 1;
+    private static final String FLAG = "--server";
 
     private final Path distribution;
     private final Path dataDir;
@@ -50,7 +50,7 @@ public class TypeDBCoreRunner implements TypeDBRunner {
         port = findUnusedPorts(1).get(0);
         System.out.println(address() + ": Constructing " + name() + " runner");
         System.out.println(address() + ": Extracting distribution archive...");
-        distribution = unarchive(getArchivePath(ARCHIVE_INDEX));
+        distribution = unarchive(getArchivePath(FLAG));
         System.out.println(address() + ": Distribution archive extracted.");
         dataDir = distribution.resolve("server").resolve("data");
         logsDir = distribution.resolve("server").resolve("logs");

--- a/test/rules.bzl
+++ b/test/rules.bzl
@@ -21,12 +21,17 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
 def typedb_java_test(name, server_mac_artifact, server_linux_artifact, server_windows_artifact,
                       console_mac_artifact = None, console_linux_artifact = None, console_windows_artifact = None,
                       native_libraries_deps = [], deps = [], classpath_resources = [], data = [], args = [], **kwargs):
-    (native_server_artifact_labels, native_server_artifact_paths, native_console_artifact_labels,
-        native_console_artifact_paths, native_deps) = create_paths_labels_nativedeps(
-           server_mac_artifact, server_linux_artifact, server_windows_artifact,
-           console_mac_artifact, console_linux_artifact, console_windows_artifact,
-           native_libraries_deps
+
+    native_server_artifact_paths, native_server_artifact_labels = native_artifact_paths_and_labels(
+           server_mac_artifact, server_linux_artifact, server_windows_artifact
+       )
+
+    native_console_artifact_paths, native_console_artifact_labels = native_console_artifact_paths_and_labels(
+            console_mac_artifact, console_linux_artifact, console_windows_artifact
         )
+
+    native_deps = add_native_libraries_deps(native_libraries_deps)
+
     native.java_test(
         name = name,
         deps = depset(deps + ["@vaticle_typedb_common//test:typedb-runner"]).to_list() + native_deps,
@@ -39,12 +44,17 @@ def typedb_java_test(name, server_mac_artifact, server_linux_artifact, server_wi
 def typedb_kt_test(name, server_mac_artifact, server_linux_artifact, server_windows_artifact,
                         console_mac_artifact = None, console_linux_artifact = None, console_windows_artifact = None,
                         native_libraries_deps = [], deps = [], data = [], args = [], **kwargs):
-    (native_server_artifact_labels, native_server_artifact_paths, native_console_artifact_labels,
-        native_console_artifact_paths, native_deps) = create_paths_labels_nativedeps(
-            server_mac_artifact, server_linux_artifact, server_windows_artifact,
-            console_mac_artifact, console_linux_artifact, console_windows_artifact,
-            native_libraries_deps
+
+    native_server_artifact_paths, native_server_artifact_labels = native_artifact_paths_and_labels(
+           server_mac_artifact, server_linux_artifact, server_windows_artifact
+       )
+
+    native_console_artifact_paths, native_console_artifact_labels = native_console_artifact_paths_and_labels(
+            console_mac_artifact, console_linux_artifact, console_windows_artifact
         )
+
+    native_deps = add_native_libraries_deps(native_libraries_deps)
+
     kt_jvm_test(
         name = name,
         deps = depset(deps + ["@vaticle_typedb_common//test:typedb-runner"]).to_list() + native_deps,
@@ -53,23 +63,20 @@ def typedb_kt_test(name, server_mac_artifact, server_linux_artifact, server_wind
         **kwargs
     )
 
-def create_paths_labels_nativedeps(server_mac_artifact, server_linux_artifact, server_windows_artifact,
-                 console_mac_artifact = None, console_linux_artifact = None, console_windows_artifact = None,
-                 native_libraries_deps = []):
-    native_server_artifact_paths, native_server_artifact_labels = native_artifact_paths_and_labels(
-           server_mac_artifact, server_linux_artifact, server_windows_artifact
-       )
-    native_console_artifact_paths, native_console_artifact_labels = [], []
-    if console_mac_artifact and console_linux_artifact and console_windows_artifact:
-       native_console_artifact_paths, native_console_artifact_labels = native_artifact_paths_and_labels(
-           console_mac_artifact, console_linux_artifact, console_windows_artifact
-       )
+def add_native_libraries_deps(native_libraries_deps):
     native_deps = []
     for dep in native_libraries_deps:
        native_deps = native_deps + native_dep_for_host_platform(dep)
+    return native_deps
 
-    return (native_server_artifact_labels, native_server_artifact_paths, native_console_artifact_labels,
-             native_console_artifact_paths, native_deps)
+
+def native_console_artifact_paths_and_labels(console_mac_artifact, console_linux_artifact, console_windows_artifact):
+    native_console_artifact_paths, native_console_artifact_labels = [], []
+    if console_mac_artifact and console_linux_artifact and console_windows_artifact:
+          native_console_artifact_paths, native_console_artifact_labels = native_artifact_paths_and_labels(
+              console_mac_artifact, console_linux_artifact, console_windows_artifact
+          )
+    return native_console_artifact_paths, native_console_artifact_labels
 
 def native_artifact_paths_and_labels(mac_artifact, linux_artifact, windows_artifact):
     native_artifacts = {

--- a/test/rules.bzl
+++ b/test/rules.bzl
@@ -66,7 +66,7 @@ def typedb_kt_test(name, server_mac_artifact, server_linux_artifact, server_wind
 def get_native_dependencies(native_libraries_deps):
     native_dependencies = []
     for dep in native_libraries_deps:
-       native_dependencies = native_deps + native_dep_for_host_platform(dep)
+       native_dependencies = native_dependencies + native_dep_for_host_platform(dep)
     return native_dependencies
 
 

--- a/test/rules.bzl
+++ b/test/rules.bzl
@@ -20,7 +20,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
 
 def typedb_java_test(name, server_mac_artifact, server_linux_artifact, server_windows_artifact,
                       console_mac_artifact = None, console_linux_artifact = None, console_windows_artifact = None,
-                      native_libraries_deps = [], deps = [], classpath_sources = [], data = [], args = [], **kwargs):
+                      native_libraries_deps = [], deps = [], classpath_resources = [], data = [], args = [], **kwargs):
     (native_server_artifact_labels, native_server_artifact_paths, native_console_artifact_labels,
         native_console_artifact_paths, native_deps) = create_paths_labels_nativedeps(
            server_mac_artifact, server_linux_artifact, server_windows_artifact,
@@ -30,7 +30,7 @@ def typedb_java_test(name, server_mac_artifact, server_linux_artifact, server_wi
     native.java_test(
         name = name,
         deps = depset(deps + ["@vaticle_typedb_common//test:typedb-runner"]).to_list() + native_deps,
-        classpath_resources = depset(classpath_sources + ["@vaticle_typedb_common//test:logback"]).to_list(),
+        classpath_resources = depset(classpath_resources + ["@vaticle_typedb_common//test:logback"]).to_list(),
         data = data + select(native_server_artifact_labels) + (select(native_console_artifact_labels) if native_console_artifact_labels else []),
         args = ["--server"] + select(native_server_artifact_paths) + ((["--console"] + select(native_console_artifact_paths)) if native_console_artifact_paths else []) + args,
         **kwargs


### PR DESCRIPTION
## What is the goal of this PR?

We extend TypeDB Runner to include support for tests run in Kotlin and refactor the way Runner finds passed archives for extraction and execution.

## What are the changes implemented in this PR?

Previously, we passed core, cluster and console archive paths to the program and delineated them by their index. Now we pass them using command line argument flags leveraging picocli as we do across other repositories for similar purposes. For example, where would previously invoke
```sh
java <BazelTestRunner> <coreRunnerArchive> <consoleRunnerArchive>
```
we now invoke
```sh
java <BazelTestRunner> --server <coreRunnerArchive> --console <consoleRunnerArchive>
```
Under the previous implementation, it wasn't possible to run the console runner alone.

Additionally, we have added a rule `typedb_kt_test` which we make use of in Studio.
