### PR TITLE
Implement lazy permutations and intersection check

### DIFF
--- a/collection/Collections.java
+++ b/collection/Collections.java
@@ -126,29 +126,34 @@ public class Collections {
             @Override
             public boolean hasNext() {
                 if (hasNext) return true;
-
                 // find the longest tail that is decreasing
                 int tailIndex = itemKeys.length - 1;
                 while (itemKeys[tailIndex] < itemKeys[tailIndex - 1]) {
                     tailIndex--;
                     if (tailIndex == 0) return false;
                 }
+                swapPreviousWithLarger(tailIndex);
+                reverseTail(tailIndex);
+                // itemKeys contains the lexicographical next permutation
+                hasNext = true;
+                return true;
+            }
 
-                // swap the next element with the smallest element larger than it in the descending tail
+            // swap the previous element with the smallest element larger than it in the descending tail
+            private void swapPreviousWithLarger(int tailIndex) {
                 for (int swap = itemKeys.length - 1; swap >= tailIndex; swap--) {
                     if (itemKeys[swap] > itemKeys[tailIndex - 1]) {
                         swap(itemKeys, swap, tailIndex - 1);
                         break;
                     }
                 }
+            }
 
-                // reverse the tail to get it back into increasing order and generate lexicographically next permutation
+            // reverse the tail to get it back into increasing order
+            private void reverseTail(int tailIndex) {
                 for (int i = tailIndex, j = itemKeys.length - 1; i < j; i++, j--) {
                     swap(itemKeys, i, j);
                 }
-
-                hasNext = true;
-                return true;
             }
 
             private void swap(int[] arr, int i, int j) {

--- a/collection/Collections.java
+++ b/collection/Collections.java
@@ -20,20 +20,12 @@ package com.vaticle.typedb.common.collection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
-import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.stream.Collectors;
-
-import static java.util.Collections.emptyIterator;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 
 public class Collections {
 

--- a/collection/Collections.java
+++ b/collection/Collections.java
@@ -33,10 +33,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyIterator;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.reverse;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.sort;
-import static java.util.Collections.swap;
 
 public class Collections {
 
@@ -103,101 +100,6 @@ public class Collections {
         return java.util.Collections.unmodifiableList(combined);
     }
 
-    /**
-     * We implement the C++ STL next_permutation method of lazily generating permutations
-     */
-    public static <T> Iterator<List<T>> permutations(Set<T> items) {
-        if (items.size() == 0) return emptyIterator();
-        else if (items.size() == 1) return singletonList(list(items.iterator().next())).iterator();
-
-        // assign a comparable ordering over the items
-        Map<Integer, T> mapping = new HashMap<>();
-        List<T> sortedItems = items.stream().sorted(Comparator.comparing(Object::toString)).collect(Collectors.toList());
-        int[] itemKeys = new int[sortedItems.size()];
-        for (int i = 0; i < sortedItems.size(); i++) {
-            mapping.put(i, sortedItems.get(i));
-            itemKeys[i] = i;
-        }
-
-        return new Iterator<List<T>>() {
-
-            boolean hasNext = true;
-
-            @Override
-            public boolean hasNext() {
-                if (hasNext) return true;
-                // find the longest tail that is decreasing
-                int tailIndex = itemKeys.length - 1;
-                while (itemKeys[tailIndex] < itemKeys[tailIndex - 1]) {
-                    tailIndex--;
-                    if (tailIndex == 0) return false;
-                }
-                swapPreviousWithLarger(tailIndex);
-                reverseTail(tailIndex);
-                // itemKeys contains the lexicographical next permutation
-                hasNext = true;
-                return true;
-            }
-
-            // swap the previous element with the smallest element larger than it in the descending tail
-            private void swapPreviousWithLarger(int tailIndex) {
-                for (int swap = itemKeys.length - 1; swap >= tailIndex; swap--) {
-                    if (itemKeys[swap] > itemKeys[tailIndex - 1]) {
-                        swap(itemKeys, swap, tailIndex - 1);
-                        break;
-                    }
-                }
-            }
-
-            // reverse the tail to get it back into increasing order
-            private void reverseTail(int tailIndex) {
-                for (int i = tailIndex, j = itemKeys.length - 1; i < j; i++, j--) {
-                    swap(itemKeys, i, j);
-                }
-            }
-
-            private void swap(int[] arr, int i, int j) {
-                int tmp = arr[i];
-                arr[i] = arr[j];
-                arr[j] = tmp;
-            }
-
-            @Override
-            public List<T> next() {
-                if (!hasNext()) throw new NoSuchElementException();
-                // convert the keys back into the items
-                List<T> permutation = new ArrayList<>(items.size());
-                for (int index : itemKeys) {
-                    permutation.add(mapping.get(index));
-                }
-                hasNext = false;
-                return permutation;
-            }
-        };
-    }
-
-
-    public static <T> List<List<T>> permutations(List<T> items) {
-        if (items.size() == 0) return singletonList(emptyList());
-        List<List<T>> permutations = singletonList(singletonList(items.get(0)));
-        for (int permutationLength = 1; permutationLength < items.size(); permutationLength++) {
-            T toInsert = items.get(permutationLength);
-            List<List<T>> extendedPermutations = new ArrayList<>();
-            for (List<T> permutation : permutations) {
-                for (int insertIndex = 0; insertIndex < permutation.size(); insertIndex++) {
-                    List<T> copy = new ArrayList<>(permutation);
-                    copy.add(insertIndex, toInsert);
-                    extendedPermutations.add(copy);
-                }
-                List<T> addedAtEnd = new ArrayList<>(permutation);
-                addedAtEnd.add(toInsert);
-                extendedPermutations.add(addedAtEnd);
-            }
-            permutations = extendedPermutations;
-        }
-        return permutations;
-    }
-
     public static <A, B> Pair<A, B> pair(A first, B second) {
         return new Pair<>(first, second);
     }
@@ -221,6 +123,22 @@ public class Collections {
             if (maxSet.contains(elem)) intersection.add(elem);
         }
         return intersection;
+    }
+
+    public static <T> boolean hasIntersection(Set<T> set1, Set<T> set2) {
+        Set<T> minSet;
+        Set<T> maxSet;
+        if (set1.size() < set2.size()) {
+            minSet = set1;
+            maxSet = set2;
+        } else {
+            minSet = set2;
+            maxSet = set1;
+        }
+        for (T elem : minSet) {
+            if (maxSet.contains(elem)) return true;
+        }
+        return false;
     }
 
     /**

--- a/collection/Permutations.java
+++ b/collection/Permutations.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static java.util.Collections.emptyIterator;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 public class Permutations {

--- a/collection/Permutations.java
+++ b/collection/Permutations.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.vaticle.typedb.common.collection;
 
 import java.util.ArrayList;
@@ -22,70 +39,77 @@ public class Permutations {
     public static <T> Iterator<List<T>> permutations(Set<T> items) {
         if (items.size() == 0) return emptyIterator();
         else if (items.size() == 1) return singletonList(list(items.iterator().next())).iterator();
+        else return new PermutationIterator<>(items);
+    }
 
-        // assign a comparable ordering over the items
-        Map<Integer, T> mapping = new HashMap<>();
-        List<T> sortedItems = items.stream().sorted(Comparator.comparing(Object::toString)).collect(Collectors.toList());
-        int[] itemKeys = new int[sortedItems.size()];
-        for (int i = 0; i < sortedItems.size(); i++) {
-            mapping.put(i, sortedItems.get(i));
-            itemKeys[i] = i;
+    private static class PermutationIterator<T> implements Iterator<List<T>> {
+
+        private final Map<Integer, T> mapping;
+        private final int[] itemKeys;
+        private boolean hasNext;
+
+        private PermutationIterator(Set<T> items) {
+            // assign a comparable ordering over the items
+            mapping = new HashMap<>();
+            // make the initial ordering mostly deterministic
+            List<T> sortedItems = items.stream().sorted(Comparator.comparing(Object::hashCode)).collect(Collectors.toList());
+            itemKeys = new int[sortedItems.size()];
+            for (int i = 0; i < sortedItems.size(); i++) {
+                mapping.put(i, sortedItems.get(i));
+                itemKeys[i] = i;
+            }
+            hasNext = true;
         }
 
-        return new Iterator<List<T>>() {
+        @Override
+        public List<T> next() {
+            if (!hasNext()) throw new NoSuchElementException();
+            // convert the keys back into the items
+            List<T> permutation = new ArrayList<>(itemKeys.length);
+            for (int index : itemKeys) {
+                permutation.add(mapping.get(index));
+            }
+            hasNext = false;
+            return permutation;
+        }
 
-            boolean hasNext = true;
+        @Override
+        public boolean hasNext() {
+            if (hasNext) return true;
+            // find the longest tail that is decreasing
+            int tailIndex = itemKeys.length - 1;
+            while (itemKeys[tailIndex] < itemKeys[tailIndex - 1]) {
+                tailIndex--;
+                if (tailIndex == 0) return false;
+            }
+            swapPreviousWithLarger(tailIndex);
+            reverseTail(tailIndex);
+            // itemKeys contains the lexicographical next permutation
+            hasNext = true;
+            return true;
+        }
+        // swap the previous element with the smallest element larger than it in the descending tail
 
-            @Override
-            public boolean hasNext() {
-                if (hasNext) return true;
-                // find the longest tail that is decreasing
-                int tailIndex = itemKeys.length - 1;
-                while (itemKeys[tailIndex] < itemKeys[tailIndex - 1]) {
-                    tailIndex--;
-                    if (tailIndex == 0) return false;
+        private void swapPreviousWithLarger(int tailIndex) {
+            for (int swap = itemKeys.length - 1; swap >= tailIndex; swap--) {
+                if (itemKeys[swap] > itemKeys[tailIndex - 1]) {
+                    swap(itemKeys, swap, tailIndex - 1);
+                    break;
                 }
-                swapPreviousWithLarger(tailIndex);
-                reverseTail(tailIndex);
-                // itemKeys contains the lexicographical next permutation
-                hasNext = true;
-                return true;
             }
+        }
+        // reverse the tail to get it back into increasing order
 
-            // swap the previous element with the smallest element larger than it in the descending tail
-            private void swapPreviousWithLarger(int tailIndex) {
-                for (int swap = itemKeys.length - 1; swap >= tailIndex; swap--) {
-                    if (itemKeys[swap] > itemKeys[tailIndex - 1]) {
-                        swap(itemKeys, swap, tailIndex - 1);
-                        break;
-                    }
-                }
+        private void reverseTail(int tailIndex) {
+            for (int i = tailIndex, j = itemKeys.length - 1; i < j; i++, j--) {
+                swap(itemKeys, i, j);
             }
+        }
 
-            // reverse the tail to get it back into increasing order
-            private void reverseTail(int tailIndex) {
-                for (int i = tailIndex, j = itemKeys.length - 1; i < j; i++, j--) {
-                    swap(itemKeys, i, j);
-                }
-            }
-
-            private void swap(int[] arr, int i, int j) {
-                int tmp = arr[i];
-                arr[i] = arr[j];
-                arr[j] = tmp;
-            }
-
-            @Override
-            public List<T> next() {
-                if (!hasNext()) throw new NoSuchElementException();
-                // convert the keys back into the items
-                List<T> permutation = new ArrayList<>(items.size());
-                for (int index : itemKeys) {
-                    permutation.add(mapping.get(index));
-                }
-                hasNext = false;
-                return permutation;
-            }
-        };
+        private void swap(int[] arr, int i, int j) {
+            int tmp = arr[i];
+            arr[i] = arr[j];
+            arr[j] = tmp;
+        }
     }
 }

--- a/collection/Permutations.java
+++ b/collection/Permutations.java
@@ -1,0 +1,113 @@
+package com.vaticle.typedb.common.collection;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.vaticle.typedb.common.collection.Collections.list;
+import static java.util.Collections.emptyIterator;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+public class Permutations {
+
+    /**
+     * We implement the C++ STL next_permutation method of lazily generating permutations
+     */
+    public static <T> Iterator<List<T>> permutations(Set<T> items) {
+        if (items.size() == 0) return emptyIterator();
+        else if (items.size() == 1) return singletonList(list(items.iterator().next())).iterator();
+
+        // assign a comparable ordering over the items
+        Map<Integer, T> mapping = new HashMap<>();
+        List<T> sortedItems = items.stream().sorted(Comparator.comparing(Object::toString)).collect(Collectors.toList());
+        int[] itemKeys = new int[sortedItems.size()];
+        for (int i = 0; i < sortedItems.size(); i++) {
+            mapping.put(i, sortedItems.get(i));
+            itemKeys[i] = i;
+        }
+
+        return new Iterator<List<T>>() {
+
+            boolean hasNext = true;
+
+            @Override
+            public boolean hasNext() {
+                if (hasNext) return true;
+                // find the longest tail that is decreasing
+                int tailIndex = itemKeys.length - 1;
+                while (itemKeys[tailIndex] < itemKeys[tailIndex - 1]) {
+                    tailIndex--;
+                    if (tailIndex == 0) return false;
+                }
+                swapPreviousWithLarger(tailIndex);
+                reverseTail(tailIndex);
+                // itemKeys contains the lexicographical next permutation
+                hasNext = true;
+                return true;
+            }
+
+            // swap the previous element with the smallest element larger than it in the descending tail
+            private void swapPreviousWithLarger(int tailIndex) {
+                for (int swap = itemKeys.length - 1; swap >= tailIndex; swap--) {
+                    if (itemKeys[swap] > itemKeys[tailIndex - 1]) {
+                        swap(itemKeys, swap, tailIndex - 1);
+                        break;
+                    }
+                }
+            }
+
+            // reverse the tail to get it back into increasing order
+            private void reverseTail(int tailIndex) {
+                for (int i = tailIndex, j = itemKeys.length - 1; i < j; i++, j--) {
+                    swap(itemKeys, i, j);
+                }
+            }
+
+            private void swap(int[] arr, int i, int j) {
+                int tmp = arr[i];
+                arr[i] = arr[j];
+                arr[j] = tmp;
+            }
+
+            @Override
+            public List<T> next() {
+                if (!hasNext()) throw new NoSuchElementException();
+                // convert the keys back into the items
+                List<T> permutation = new ArrayList<>(items.size());
+                for (int index : itemKeys) {
+                    permutation.add(mapping.get(index));
+                }
+                hasNext = false;
+                return permutation;
+            }
+        };
+    }
+
+    public static <T> List<List<T>> permutations(List<T> items) {
+        if (items.size() == 0) return singletonList(emptyList());
+        List<List<T>> permutations = singletonList(singletonList(items.get(0)));
+        for (int permutationLength = 1; permutationLength < items.size(); permutationLength++) {
+            T toInsert = items.get(permutationLength);
+            List<List<T>> extendedPermutations = new ArrayList<>();
+            for (List<T> permutation : permutations) {
+                for (int insertIndex = 0; insertIndex < permutation.size(); insertIndex++) {
+                    List<T> copy = new ArrayList<>(permutation);
+                    copy.add(insertIndex, toInsert);
+                    extendedPermutations.add(copy);
+                }
+                List<T> addedAtEnd = new ArrayList<>(permutation);
+                addedAtEnd.add(toInsert);
+                extendedPermutations.add(addedAtEnd);
+            }
+            permutations = extendedPermutations;
+        }
+        return permutations;
+    }
+}

--- a/collection/Permutations.java
+++ b/collection/Permutations.java
@@ -89,25 +89,4 @@ public class Permutations {
             }
         };
     }
-
-    public static <T> List<List<T>> permutations(List<T> items) {
-        if (items.size() == 0) return singletonList(emptyList());
-        List<List<T>> permutations = singletonList(singletonList(items.get(0)));
-        for (int permutationLength = 1; permutationLength < items.size(); permutationLength++) {
-            T toInsert = items.get(permutationLength);
-            List<List<T>> extendedPermutations = new ArrayList<>();
-            for (List<T> permutation : permutations) {
-                for (int insertIndex = 0; insertIndex < permutation.size(); insertIndex++) {
-                    List<T> copy = new ArrayList<>(permutation);
-                    copy.add(insertIndex, toInsert);
-                    extendedPermutations.add(copy);
-                }
-                List<T> addedAtEnd = new ArrayList<>(permutation);
-                addedAtEnd.add(toInsert);
-                extendedPermutations.add(addedAtEnd);
-            }
-            permutations = extendedPermutations;
-        }
-        return permutations;
-    }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We impement lazy permutation generation and a short-circuiting intersection existence check.

## What are the changes implemented in this PR?

* create new `collections/Permutations` which contains a lazy permutation generator and a non-lazy permutation generator
  * lazy permutation generator follows C++ `next_permutation` algorithm - explanation at https://stackoverflow.com/questions/352203/generating-permutations-lazily
* implement an optimised intersection existence check which doesn't require computing the entire intersection set