### PR TITLE
Rename Grabl to Factory

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -31,7 +31,7 @@ build:
         SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
           bazel run @vaticle_dependencies//tool/sonarcloud:code-analysis -- \
           --project-key=vaticle_typedb_common \
-          --branch=$GRABL_BRANCH --commit-id=$GRABL_COMMIT
+          --branch=$FACTORY_BRANCH --commit-id=$FACTORY_COMMIT
     dependency-analysis:
       image: vaticle-ubuntu-21.04
       command: |
@@ -87,9 +87,9 @@ release:
         pyenv global 3.6.10 system
         pip3 install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run @vaticle_dependencies//tool/release/notes:create -- $GRABL_OWNER $GRABL_REPO $GRABL_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
+        bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
+        bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     deploy-maven-release:
       image: vaticle-ubuntu-21.04
       dependencies: [deploy-github]

--- a/BUILD
+++ b/BUILD
@@ -80,7 +80,7 @@ checkstyle_test(
     include = glob([
         ".bazelrc",
         ".gitignore",
-        ".grabl/automation.yml",
+        ".factory/automation.yml",
         "BUILD",
         "WORKSPACE",
         "collection/*",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TypeDB Common
 
-[![Grabl](https://grabl.io/api/status/vaticle/typedb-common/badge.svg)](https://grabl.io/vaticle/typedb-common)
+[![Factory](https://factory.vaticle.com/api/status/vaticle/typedb-common/badge.svg)](https://factory.vaticle.com/vaticle/typedb-common)
 
 Common libraries and scripts reused across TypeDB repositories and community projects.

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,6 +20,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/jamesreprise/dependencies",
-        commit = "c555ac002ae78b5377c0c124a32ec233ecb33a48", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "0e72bc924d188c4dbe13a33908971f23156ad001", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,5 +21,5 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/jamesreprise/dependencies",
-        commit = "ef96426023da17c6294e645848ec5515caae6afa", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "c555ac002ae78b5377c0c124a32ec233ecb33a48", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,6 +20,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "a8b3b714a5e0562d41f4c05ca8f266d48b7d0fd3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/jamesreprise/dependencies",
+        commit = "ef96426023da17c6294e645848ec5515caae6afa", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )


### PR DESCRIPTION
## What is the goal of this PR?

We've changed all instances of Grabl to Factory in line with the change in name of our CI.

## What are the changes implemented in this PR?

- We've renamed our `.grabl` CI config file to `.factory`.
- We've replaced all references to grabl.io with factory.vaticle.com.
- We've replaced our environment variables that use the name GRABL with ones that use FACTORY.
