### PR TITLE
Re-instate use of pyenv

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -68,6 +68,13 @@ build:
       command: |
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
+        # Do not upgrade Python until bazelbuild/rules_pkg#397 is fixed
+        export PYENV_ROOT="/opt/pyenv"
+        pyenv install 3.7.9
+        pyenv global 3.7.9
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
         bazel run --define version=$(git rev-parse HEAD) //binary:deploy-apt -- snapshot
 release:
   filter:
@@ -77,6 +84,10 @@ release:
     deploy-github:
       image: vaticle-ubuntu-22.04
       command: |
+        export PYENV_ROOT="/opt/pyenv"
+        pyenv install -s 3.6.10
+        pyenv global 3.6.10 system
+        python3 -m pip install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
@@ -95,4 +106,11 @@ release:
         cat VERSION
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
+        # Do not upgrade Python until bazelbuild/rules_pkg#397 is fixed
+        export PYENV_ROOT="/opt/pyenv"
+        pyenv install 3.7.9
+        pyenv global 3.7.9
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
         bazel run --define version=$(cat VERSION) //binary:deploy-apt -- release

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -87,6 +87,9 @@ release:
         export PYENV_ROOT="/opt/pyenv"
         pyenv install -s 3.6.10
         pyenv global 3.6.10 system
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
         python3 -m pip install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md


### PR DESCRIPTION
## What is the goal of this PR?

We've re-instated the use of pyenv in certain Factory job definitions. Removing it in favour of using the system python3 had far-reaching ramifications that proved too costly to immediately address.

## What are the changes implemented in this PR?

We've re-instated our use of pyenv in `deploy-github`, `deploy-apt-snapshot` and `deploy-apt-release`.