### PR TITLE
Bump version of python installed by pyenv for github deployment

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -85,8 +85,8 @@ release:
       image: vaticle-ubuntu-22.04
       command: |
         export PYENV_ROOT="/opt/pyenv"
-        pyenv install -s 3.6.10
-        pyenv global 3.6.10 system
+        pyenv install 3.7.9
+        pyenv global 3.7.9
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
         sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py

--- a/deployment.bzl
+++ b/deployment.bzl
@@ -17,5 +17,5 @@
 
 deployment = {
   'github.organisation': 'vaticle',
-  'github.repository': 'common'
+  'github.repository': 'typedb-common'
 }


### PR DESCRIPTION
## What is the goal of this PR?

We've bumped the version of python installed by pyenv to resolve a segfault when building Python 3.6.10 on our current CI machines. 

## What are the changes implemented in this PR?

We've bumped the version of python installed by pyenv from 3.6.10 to 3.7.9.
We've also ensured we're referencing `typedb-common` as the repository as opposed to `common`.