### PR TITLE
Include TypeDB runners in common library jar

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -27,11 +27,15 @@ load("//:deployment.bzl", deployment_github = "deployment")
 java_library(
     name = "common",
     srcs = glob([
+        "test/*.java",
+        "test/cluster/*.java",
+        "test/console/*.java",
+        "test/core/*.java",
         "collection/*.java",
         "concurrent/*.java",
         "concurrent/actor/*.java",
         "concurrent/actor/eventloop/*.java",
-        "conf/*/*.java",
+        "conf/cluster/*.java",
         "exception/*.java",
         "util/*.java",
         "yaml/*.java",


### PR DESCRIPTION
## What is the goal of this PR?

Currently, we don't include the test directory files in the main jar produced by typedb-common. As raised by a community member, we should include this so other people can make use of this via the provided jars.

## What are the changes implemented in this PR?

We've included all of the java files found under //test in the `srcs` argument to `java_library`.

We've also corrected one scary \*/\* import and now explicitly specify what directory is being brought in.