### PR TITLE
Fix TypeDB Windows Launcher UX

### DIFF
--- a/binary/typedb.bat
+++ b/binary/typedb.bat
@@ -15,8 +15,8 @@ REM You should have received a copy of the GNU Affero General Public License
 REM along with this program.  If not, see <https://www.gnu.org/licenses/>.
 REM
 
-SET "TYPEDB_HOME=%cd%"
-
+SET "TYPEDB_HOME=%~dp0"
+IF %TYPEDB_HOME:~-1%==\ SET TYPEDB_HOME=%TYPEDB_HOME:~0,-1%
 
 where java >NUL 2>NUL
 if %ERRORLEVEL% GEQ 1 (
@@ -51,8 +51,8 @@ goto exiterror
 :startconsole
 
 set "G_CP=%TYPEDB_HOME%\console\conf\;%TYPEDB_HOME%\console\lib\*"
-if exist .\console\ (
-  java %CONSOLE_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.console.TypeDBConsole %2 %3 %4 %5 %6 %7 %8 %9
+if exist "%TYPEDB_HOME%\console\" (
+  start java %CONSOLE_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.console.TypeDBConsole %2 %3 %4 %5 %6 %7 %8 %9
   goto exit
 ) else (
   echo TypeDB Console is not included in this TypeDB distribution^.
@@ -63,10 +63,11 @@ if exist .\console\ (
 :startserver
 
 set "G_CP=%TYPEDB_HOME%\server\conf\;%TYPEDB_HOME%\server\lib\common\*;%TYPEDB_HOME%\server\lib\prod\*"
+echo "%G_CP%"
+echo "%TYPEDB_HOME%"
 
-
-if exist .\server\ (
-  java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.core.server.TypeDBServer %2 %3 %4 %5 %6 %7 %8 %9
+if exist "%TYPEDB_HOME%\server\" (
+  start java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.core.server.TypeDBServer %2 %3 %4 %5 %6 %7 %8 %9
   goto exit
 ) else (
   echo TypeDB Server is not included in this TypeDB distribution^.
@@ -78,8 +79,8 @@ if exist .\server\ (
 
 set "G_CP=%TYPEDB_HOME%\server\conf\;%TYPEDB_HOME%\server\lib\common\*;%TYPEDB_HOME%\server\lib\prod\*"
 
-if exist .\server\ (
-  java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.cluster.server.TypeDBClusterServer %2 %3 %4 %5 %6 %7 %8 %9
+if exist "%TYPEDB_HOME%\server\" (
+  start java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.cluster.server.TypeDBClusterServer %2 %3 %4 %5 %6 %7 %8 %9
   goto exit
 ) else (
   echo TypeDB Cluster is not included in this TypeDB distribution^.


### PR DESCRIPTION
## What is the goal of this PR?

We can now launch TypeDB from any folder in Windows (provided TypeDB has been added to the user's environment).
TypeDB also gets launched in a new window, which the user can freely close or quit via Ctrl+C without interruption once they are finished.

Fixes https://github.com/vaticle/typedb/issues/6780
Fixes https://github.com/vaticle/typedb/issues/6781

## What are the changes implemented in this PR?

We've refactored 'typedb.bat' to use the absolute path rather than relative, allowing the command to be used from anywhere.
We've added the keyword `start` before running the server via Java. This launches the server in a new window.
