### PR TITLE
Isolate runner environments

### DIFF
--- a/test/cluster/TypeDBClusterRunner.java
+++ b/test/cluster/TypeDBClusterRunner.java
@@ -79,12 +79,12 @@ public class TypeDBClusterRunner implements TypeDBRunner {
 
     private static Set<Addresses> allocateAddressesSet(int serverCount) {
         Set<Addresses> addresses = new HashSet<>();
+        List<Integer> ports = Util.findUnusedPorts(serverCount * 3);
         for (int i = 0; i < serverCount; i++) {
-            List<Integer> ports = Util.findUnusedPorts(3);
             String host = "127.0.0.1";
-            int externalPort = ports.get(0);
-            int internalPortZMQ = ports.get(1);
-            int internalPortGRPC = ports.get(2);
+            int externalPort = ports.get(3 * i);
+            int internalPortZMQ = ports.get(3 * i + 1);
+            int internalPortGRPC = ports.get(3 * i + 2);
             addresses.add(Addresses.create(host, externalPort, host, internalPortZMQ, host, internalPortGRPC));
         }
         return addresses;

--- a/test/cluster/TypeDBClusterRunner.java
+++ b/test/cluster/TypeDBClusterRunner.java
@@ -20,13 +20,16 @@ package com.vaticle.typedb.common.test.cluster;
 
 import com.vaticle.typedb.common.conf.cluster.Addresses;
 import com.vaticle.typedb.common.test.TypeDBRunner;
+import com.vaticle.typedb.common.test.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -54,6 +57,7 @@ public class TypeDBClusterRunner implements TypeDBRunner {
                                              TypeDBClusterServerRunner.Factory serverRunnerFactory) {
         Set<Addresses> serverAddressesSet = allocateAddressesSet(serverCount);
         Map<Addresses, Map<String, String>> serverOptionsMap = new HashMap<>();
+        clusterRunnerDir = clusterRunnerDir.resolve(java.util.UUID.randomUUID().toString());
         for (Addresses addrs: serverAddressesSet) {
             Map<String, String> options = new HashMap<>();
             options.putAll(serverOptions);
@@ -76,10 +80,11 @@ public class TypeDBClusterRunner implements TypeDBRunner {
     private static Set<Addresses> allocateAddressesSet(int serverCount) {
         Set<Addresses> addresses = new HashSet<>();
         for (int i = 0; i < serverCount; i++) {
+            List<Integer> ports = Util.findUnusedPorts(3);
             String host = "127.0.0.1";
-            int externalPort = 30000 + i * 1111;
-            int internalPortZMQ = 40000 + i * 1111;
-            int internalPortGRPC = 50000 + i * 1111;
+            int externalPort = ports.get(0);
+            int internalPortZMQ = ports.get(1);
+            int internalPortGRPC = ports.get(2);
             addresses.add(Addresses.create(host, externalPort, host, internalPortZMQ, host, internalPortGRPC));
         }
         return addresses;

--- a/test/cluster/TypeDBClusterServerRunner.java
+++ b/test/cluster/TypeDBClusterServerRunner.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
 import static com.vaticle.typedb.common.test.Util.createProcessExecutor;
@@ -117,7 +116,7 @@ public interface TypeDBClusterServerRunner extends TypeDBRunner {
         public List<String> command() {
             List<String> cmd = new ArrayList<>();
             cmd.add("cluster");
-            serverOptions.forEach((key, value) -> cmd.add(value.isEmpty() ? key : key + "=" + value));
+            serverOptions.forEach((key, value) -> cmd.add(key + "=" + value));
             return Util.typeDBCommand(cmd);
         }
 

--- a/test/cluster/TypeDBClusterServerRunner.java
+++ b/test/cluster/TypeDBClusterServerRunner.java
@@ -117,7 +117,7 @@ public interface TypeDBClusterServerRunner extends TypeDBRunner {
         public List<String> command() {
             List<String> cmd = new ArrayList<>();
             cmd.add("cluster");
-            serverOptions.forEach((key, value) -> cmd.add(key + "=" + value));
+            serverOptions.forEach((key, value) -> cmd.add(value.isEmpty() ? key : key + "=" + value));
             return Util.typeDBCommand(cmd);
         }
 
@@ -131,14 +131,12 @@ public interface TypeDBClusterServerRunner extends TypeDBRunner {
             if (process != null) {
                 try {
                     System.out.println(addresses() + ": Stopping...");
-                    CompletableFuture<Process> future = process.getProcess().onExit();
-                    process.getProcess().destroy();
-                    future.get();
+                    process.getProcess().destroyForcibly();
                     process = null;
                     System.out.println(addresses() + ": Stopped.");
                 } catch (Exception e) {
                     printLogs();
-//                    throw e;
+                    throw e;
                 }
             }
         }

--- a/test/cluster/TypeDBClusterServerRunner.java
+++ b/test/cluster/TypeDBClusterServerRunner.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
 import static com.vaticle.typedb.common.test.Util.createProcessExecutor;
@@ -130,7 +131,9 @@ public interface TypeDBClusterServerRunner extends TypeDBRunner {
             if (process != null) {
                 try {
                     System.out.println(addresses() + ": Stopping...");
+                    CompletableFuture<Process> future = process.getProcess().onExit();
                     process.getProcess().destroyForcibly();
+                    future.get();
                     process = null;
                     System.out.println(addresses() + ": Stopped.");
                 } catch (Exception e) {

--- a/test/cluster/TypeDBClusterServerRunner.java
+++ b/test/cluster/TypeDBClusterServerRunner.java
@@ -132,13 +132,13 @@ public interface TypeDBClusterServerRunner extends TypeDBRunner {
                 try {
                     System.out.println(addresses() + ": Stopping...");
                     CompletableFuture<Process> future = process.getProcess().onExit();
-                    process.getProcess().destroyForcibly();
+                    process.getProcess().destroy();
                     future.get();
                     process = null;
                     System.out.println(addresses() + ": Stopped.");
                 } catch (Exception e) {
                     printLogs();
-                    throw e;
+//                    throw e;
                 }
             }
         }


### PR DESCRIPTION
## What is the goal of this PR?

We prevent runners from ever using each others ports or file system state by always assigning random ports for the runners and always generating a new folder (via a random UUID) for the storage.

## What are the changes implemented in this PR?

We now find as many unused ports as necessary and create a new folder with a random UUID as a name for each runner (which may contain multiple servers).