### PR TITLE
Allow resetting and deleting the files of TypeDB Runners

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,6 @@
 
 # try-import /opt/credentials/bazel-remote-cache.rc
 
-build --incompatible_strict_action_env --javacopt='--release 8'
+build --incompatible_strict_action_env --java_language_version=11 --javacopt='--release 11'
 run --incompatible_strict_action_env
 test --incompatible_strict_action_env

--- a/test/TypeDBRunner.java
+++ b/test/TypeDBRunner.java
@@ -28,5 +28,5 @@ public interface TypeDBRunner {
 
     void stop();
 
-
+    void destroy();
 }

--- a/test/TypeDBRunner.java
+++ b/test/TypeDBRunner.java
@@ -28,5 +28,7 @@ public interface TypeDBRunner {
 
     void stop();
 
-    void destroy();
+    void deleteFiles();
+
+    void reset();
 }

--- a/test/TypeDBSingleton.java
+++ b/test/TypeDBSingleton.java
@@ -25,6 +25,19 @@ public class TypeDBSingleton {
         typeDBRunner = instance;
     }
 
+    public static void resetTypeDBRunner() {
+        if (typeDBRunner != null) {
+            typeDBRunner.reset();
+        }
+    }
+
+    public static void deleteTypeDBRunner() {
+        if (typeDBRunner != null) {
+            typeDBRunner.deleteFiles();
+            typeDBRunner = null;
+        }
+    }
+
     public static TypeDBRunner getTypeDBRunner() {
         return typeDBRunner;
     }

--- a/test/Util.java
+++ b/test/Util.java
@@ -96,7 +96,7 @@ public class Util {
     public static void deleteDirectoryContents(Path directory) throws IOException {
         Path finalDirectory = directory.toAbsolutePath();
         if (!finalDirectory.toFile().exists()) return;
-        Files.walkFileTree(finalDirectory, new SimpleFileVisitor<>() {
+        Files.walkFileTree(finalDirectory, new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
                 if (path.toFile().exists()) {

--- a/test/Util.java
+++ b/test/Util.java
@@ -28,9 +28,12 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -75,12 +78,7 @@ public class Util {
 
     public static Path unarchive(File archive) throws IOException, TimeoutException, InterruptedException {
         Path runnerDir = Files.createTempDirectory("typedb");
-        ProcessExecutor executor = new ProcessExecutor()
-                .directory(Paths.get(".").toAbsolutePath().toFile())
-                .redirectOutput(System.out)
-                .redirectError(System.err)
-                .readOutput(true)
-                .destroyOnExit();
+        ProcessExecutor executor = createProcessExecutor(Paths.get(".").toAbsolutePath());
         if (archive.toString().endsWith(TAR_GZ)) {
             executor.command("tar", "-xf", archive.toString(),
                     "-C", runnerDir.toString()).execute();
@@ -93,6 +91,31 @@ public class Util {
         // The TypeDB Cluster archive extracts to a folder inside TYPEDB_TARGET_DIRECTORY named
         // typedb-server-{platform}-{version}. We know it's the only folder, so we can retrieve it using Files.list.
         return Files.list(runnerDir).findFirst().get().toAbsolutePath();
+    }
+
+    public static void deleteDirectoryContents(Path directory) throws IOException {
+        Path finalDirectory = directory.toAbsolutePath();
+        if (!finalDirectory.toFile().exists()) return;
+        Files.walkFileTree(finalDirectory, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
+                if (path.toFile().exists()) {
+                    Files.delete(path);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
+                if (e == null) {
+                    if (dir.toFile().exists() && dir.toAbsolutePath() != finalDirectory.toAbsolutePath()) {
+                        Files.delete(dir);
+                    }
+                } else {
+                    throw e;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 
     public static List<String> typeDBCommand(String... cmd) {

--- a/test/cluster/ClusterServerOpts.java
+++ b/test/cluster/ClusterServerOpts.java
@@ -93,6 +93,10 @@ class ClusterServerOpts {
         return Paths.get(options.get(STORAGE_DATA));
     }
 
+    static Path storageReplication(Map<String, String> options) {
+        return Paths.get(options.get(STORAGE_REPLICATION));
+    }
+
     static Path logOutput(Map<String, String> options) {
         return Paths.get(options.get(LOG_OUTPUT_FILE_DIRECTORY));
     }

--- a/test/cluster/TypeDBClusterRunner.java
+++ b/test/cluster/TypeDBClusterRunner.java
@@ -24,12 +24,13 @@ import com.vaticle.typedb.common.test.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -43,6 +44,7 @@ public class TypeDBClusterRunner implements TypeDBRunner {
     protected final Map<Addresses, Map<String, String>> serverOptionsMap;
     private final TypeDBClusterServerRunner.Factory serverRunnerFactory;
     protected final Map<Addresses, TypeDBClusterServerRunner> serverRunners;
+    private static Path runnerPath;
 
     public static TypeDBClusterRunner create(Path clusterRunnerDir, int serverCount) {
         return create(clusterRunnerDir, serverCount, new HashMap<>(),
@@ -57,6 +59,7 @@ public class TypeDBClusterRunner implements TypeDBRunner {
                                              TypeDBClusterServerRunner.Factory serverRunnerFactory) {
         Set<Addresses> serverAddressesSet = allocateAddressesSet(serverCount);
         Map<Addresses, Map<String, String>> serverOptionsMap = new HashMap<>();
+        runnerPath = clusterRunnerDir;
         clusterRunnerDir = clusterRunnerDir.resolve(java.util.UUID.randomUUID().toString());
         for (Addresses addrs: serverAddressesSet) {
             Map<String, String> options = new HashMap<>();
@@ -161,6 +164,18 @@ public class TypeDBClusterRunner implements TypeDBRunner {
             } else {
                 LOG.debug("not stopping server {} - it is already stopped.", runner.addresses());
             }
+        }
+    }
+
+    @Override
+    public void destroy() {
+        stop();
+        try {
+            Files.delete(runnerPath);
+        }
+        catch (IOException e) {
+            System.out.println("Unable to delete distribution " + runnerPath.toAbsolutePath());
+            e.printStackTrace();
         }
     }
 }

--- a/test/cluster/TypeDBClusterServerRunner.java
+++ b/test/cluster/TypeDBClusterServerRunner.java
@@ -140,6 +140,18 @@ public interface TypeDBClusterServerRunner extends TypeDBRunner {
             }
         }
 
+        @Override
+        public void destroy() {
+            stop();
+            try {
+                Files.delete(distribution);
+            }
+            catch (IOException e) {
+                System.out.println("Unable to delete distribution " + distribution.toAbsolutePath());
+                e.printStackTrace();
+            }
+        }
+
         private void printLogs() {
             System.out.println(addresses() + ": ================");
             System.out.println(addresses() + ": Logs:");

--- a/test/core/TypeDBCoreRunner.java
+++ b/test/core/TypeDBCoreRunner.java
@@ -25,6 +25,7 @@ import org.zeroturnaround.exec.StartedProcess;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
@@ -113,6 +114,18 @@ public class TypeDBCoreRunner implements TypeDBRunner {
                 printLogs();
                 throw e;
             }
+        }
+    }
+
+    @Override
+    public void destroy() {
+        stop();
+        try {
+            Files.delete(distribution);
+        }
+        catch (IOException e) {
+            System.out.println("Unable to delete distribution " + distribution.toAbsolutePath());
+            e.printStackTrace();
         }
     }
 

--- a/test/core/TypeDBCoreRunner.java
+++ b/test/core/TypeDBCoreRunner.java
@@ -25,9 +25,10 @@ import org.zeroturnaround.exec.StartedProcess;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
 import static com.vaticle.typedb.common.test.Util.createProcessExecutor;
@@ -100,7 +101,7 @@ public class TypeDBCoreRunner implements TypeDBRunner {
 
     @Override
     public boolean isStopped() {
-        return !process.getProcess().isAlive();
+        return process == null || !process.getProcess().isAlive();
     }
 
     @Override
@@ -108,26 +109,45 @@ public class TypeDBCoreRunner implements TypeDBRunner {
         if (process != null) {
             try {
                 System.out.println(address() + ": Stopping...");
-                process.getProcess().destroyForcibly();
+                CompletableFuture<Process> processFuture = process.getProcess().onExit();
+                process.getProcess().destroy();
+                processFuture.get();
+                process = null;
                 System.out.println(address() + ": Stopped.");
             } catch (Exception e) {
+                System.out.println("Unable to destroy runner.");
                 printLogs();
-                throw e;
             }
         }
     }
 
+
     @Override
-    public void destroy() {
+    public void deleteFiles() {
         stop();
         try {
-            Files.delete(distribution);
+            Util.deleteDirectoryContents(distribution);
         }
         catch (IOException e) {
             System.out.println("Unable to delete distribution " + distribution.toAbsolutePath());
             e.printStackTrace();
         }
     }
+
+    @Override
+    public void reset() {
+        stop();
+        List<Path> paths = Arrays.asList(dataDir, logsDir);
+        paths.forEach(path -> {
+            try {
+                Util.deleteDirectoryContents(path);
+            } catch (IOException e) {
+                System.out.println("Unable to delete " + path.toAbsolutePath());
+                e.printStackTrace();
+            }
+        });
+    }
+
 
     private void printLogs() {
         System.out.println(address() + ": ================");


### PR DESCRIPTION
## What is the goal of this PR?

We've enabled resetting and deleting the associated files for any TypeDBRunner. Resetting the Runner allows the saving of space by only deleting the state, rather than having to create a new runner.

We've also changed the Java language level to 11 for this project via Bazel.

## What are the changes implemented in this PR?

We've added two methods to the TypeDBRunner interface: 
* `reset()`: deleting all of the state for TypeDB, essentially ensuring that on next boot a new system will be created without requiring the creation of a new runner (which involves unarchiving a distribution).
* `deleteFiles()`: deleting all of the TypeDB runner files, clearing space as needed.

We've also added a utility method `deleteDirectoryContents()`.

We've also changed the Java language arguments in .bazelrc: 
```
-java_language_version=11 --javacopt='--release 11'
```