### PR TITLE
Update typedb startup scripts to reflect simplified dependencies folder

### DIFF
--- a/binary/typedb
+++ b/binary/typedb
@@ -63,9 +63,9 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "cluster" ]]; then
 
     TYPEDB_SERVER_DIR="${TYPEDB_HOME}/server"
     TYPEDB_SERVER_LIB_DIR="${TYPEDB_SERVER_DIR}/lib"
-    TYPEDB_CLUSTER_SERVER_JAR=("${TYPEDB_SERVER_LIB_DIR}"/common/com-vaticle-typedb-typedb-cluster-server-*.jar)
+    TYPEDB_CLUSTER_SERVER_JAR=("${TYPEDB_SERVER_LIB_DIR}"/com-vaticle-typedb-typedb-cluster-server-*.jar)
 
-    CLASSPATH="${TYPEDB_SERVER_DIR}/conf/:${TYPEDB_SERVER_LIB_DIR}/common/*"
+    CLASSPATH="${TYPEDB_SERVER_DIR}/conf/:${TYPEDB_SERVER_LIB_DIR}/*"
 
     if [[ "$1" = "server" ]]; then
         TYPEDB_ALL_NAME="TypeDB (All)"
@@ -98,15 +98,9 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "cluster" ]]; then
 
     # exec replaces current shell process with java so no commands after these ones will ever get executed
     if [ $DEBUG ]; then
-        case "$(uname -s)" in
-            Darwin) CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/dev/*" ;;
-            *) echo "WARNING: Debug mode RocksDB is not available in this platform. Fallback to production mode."
-               CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/prod/*" ;;
-        esac
         exec $JAVA_BIN ${JAVAOPTS} -ea -cp "${CLASSPATH}" -Dtypedb.dir="${TYPEDB_HOME}" \
             ${TYPEDB_SERVER_CLASS} "${@:2}"
     else
-        CLASSPATH="${CLASSPATH}:$TYPEDB_SERVER_LIB_DIR/prod/*"
         exec $JAVA_BIN ${JAVAOPTS} -cp "${CLASSPATH}" -Dtypedb.dir="${TYPEDB_HOME}" \
             ${TYPEDB_SERVER_CLASS} "${@:2}"
     fi

--- a/binary/typedb.bat
+++ b/binary/typedb.bat
@@ -62,7 +62,7 @@ if exist "%TYPEDB_HOME%\console\" (
 
 :startserver
 
-set "G_CP=%TYPEDB_HOME%\server\conf\;%TYPEDB_HOME%\server\lib\common\*;%TYPEDB_HOME%\server\lib\prod\*"
+set "G_CP=%TYPEDB_HOME%\server\conf\;%TYPEDB_HOME%\server\lib\*"
 echo "%G_CP%"
 echo "%TYPEDB_HOME%"
 
@@ -77,7 +77,7 @@ if exist "%TYPEDB_HOME%\server\" (
 
 :startcluster
 
-set "G_CP=%TYPEDB_HOME%\server\conf\;%TYPEDB_HOME%\server\lib\common\*;%TYPEDB_HOME%\server\lib\prod\*"
+set "G_CP=%TYPEDB_HOME%\server\conf\;%TYPEDB_HOME%\server\lib\*"
 
 if exist "%TYPEDB_HOME%\server\" (
   start java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.cluster.server.TypeDBClusterServer %2 %3 %4 %5 %6 %7 %8 %9


### PR DESCRIPTION
## What is the goal of this PR?
Updates typedb startup scripts (`typedb` and `typedb.bat`) to reflect the simplified directory structure of server/lib introduced in [typedb#6821](https://github.com/vaticle/typedb/pull/6821) 

## What are the changes implemented in this PR?
* Updates the script to remove the switch of classpaths between ( `server/lib/{dev <--> prod}` when the --debug flag is set on mac)
* Simplifies the classpath to be `/server/lib/*` instead of `/server/lib/common/*:/server/lib/{dev,prod}/*`
