### PR TITLE
Update TypeDB Runner log output flag

### DIFF
--- a/test/cluster/ClusterServerOpts.java
+++ b/test/cluster/ClusterServerOpts.java
@@ -40,7 +40,7 @@ class ClusterServerOpts {
     static final String STORAGE_DATA = "--storage.data";
     static final String STORAGE_REPLICATION = "--storage.replication";
     static final String STORAGE_USER = "--storage.user";
-    static final String LOG_OUTPUT_FILE_DIRECTORY = "--log.output.file.directory";
+    static final String LOG_OUTPUT_FILE_DIRECTORY = "--log.output.file.base-dir";
 
     static Addresses address(Map<String, String> options) {
         return Addresses.create(options.get(ADDR), options.get(INTERNAL_ADDR_ZMQ), options.get(INTERNAL_ADDR_GRPC));


### PR DESCRIPTION
## What is the goal of this PR?

As of https://github.com/vaticle/typedb/pull/6864, TypeDB has changed the name of the configuration argument to set the log file directory from `directory` to `base-dir`

## What are the changes implemented in this PR?

- Update `--log.output.file.directory` to `--log.output.file.base-dir`
