### PR TITLE
Ensure TypeDB processes spawned by tests use the same java installation

### DIFF
--- a/test/Util.java
+++ b/test/Util.java
@@ -236,6 +236,7 @@ public class Util {
                 .redirectOutput(System.out)
                 .redirectError(System.err)
                 .readOutput(true)
+                .environment("JAVA_HOME", System.getProperty("java.home"))
                 .destroyOnExit();
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
We ensure the TypeDB process spawned by the runner utility uses the same java version as the test. This avoids issues due to the runner using a different java installation from the host machine.

## What are the changes implemented in this PR?
* Sets the `JAVA_HOME` environment variable on the `ProcessExecutor` used by TypeDB (core & enterprise) runners.