### PR TITLE
Remove apt deployment

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -60,16 +60,6 @@ build:
         export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //:deploy-maven -- snapshot
         bazel run --define version=$(git rev-parse HEAD) //test:deploy-maven -- snapshot
-    deploy-apt-snapshot:
-      filter:
-        owner: vaticle
-        branch: master
-      image: vaticle-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //binary:deploy-apt -- snapshot
 release:
   filter:
     owner: vaticle
@@ -90,11 +80,3 @@ release:
         export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run --define version=$(cat VERSION) //:deploy-maven -- release
         bazel run --define version=$(cat VERSION) //test:deploy-maven -- release
-    deploy-apt-release:
-      image: vaticle-ubuntu-22.04
-      dependencies: [deploy-github]
-      command: |
-        cat VERSION
-        export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run --define version=$(cat VERSION) //binary:deploy-apt -- release

--- a/binary/BUILD
+++ b/binary/BUILD
@@ -39,6 +39,7 @@ assemble_targz(
     additional_files = {
         "//binary:typedb.service": "typedb.service",
     },
+    visibility = ["//visibility:public"]
 )
 
 assemble_targz(
@@ -47,34 +48,6 @@ assemble_targz(
         "//binary:typedb.bat": "typedb.bat",
     },
     visibility = ["//visibility:public"]
-)
-
-assemble_apt(
-    name = "assemble-linux-apt",
-    package_name = "typedb-bin",
-    maintainer = "Vaticle <community@vaticle.com>",
-    description = "TypeDB (binaries)",
-    archives = [":assemble-bash-targz", ":assemble-apt-targz"],
-    installation_dir = "/opt/typedb/core/",
-    empty_dirs = [
-        "var/log/typedb/",
-    ],
-    empty_dirs_permission = "0777",
-    symlinks = {
-        "usr/local/bin/typedb": "/opt/typedb/core/typedb",
-        "opt/typedb/core/server/logs": "/var/log/typedb/",
-        "usr/lib/systemd/system/typedb.service": "/opt/typedb/core/typedb.service",
-    },
-    depends = [
-        "openjdk-11-jre"
-    ],
-)
-
-deploy_apt(
-    name = "deploy-apt",
-    target = ":assemble-linux-apt",
-    snapshot = deployment['apt.snapshot'],
-    release = deployment['apt.release']
 )
 
 checkstyle_test(


### PR DESCRIPTION
## What is the goal of this PR?

We no longer deploy `typedb-binary` as a separate package, but rather a single package called `typedb` which contains server, console, and the binary. See https://github.com/vaticle/typedb/pull/6935.