### PR TITLE
Improve entry point runner UX

### DIFF
--- a/binary/typedb
+++ b/binary/typedb
@@ -24,6 +24,11 @@ fi
 [[ $(readlink $0) ]] && path=$(readlink $0) || path=$0
 TYPEDB_HOME=$(cd "$(dirname "${path}")" && pwd -P)
 
+TYPEDB_SERVER_DIR="${TYPEDB_HOME}/server"
+
+SERVER_PRESENT=$([[ -d "$TYPEDB_SERVER_DIR" ]] && echo yes)
+CONSOLE_PRESENT=$([[ -d "${TYPEDB_HOME}/console" ]] && echo yes)
+
 # ================================================
 # common helper functions
 # ================================================
@@ -37,78 +42,77 @@ exit_if_java_not_found() {
     fi
 }
 
+print_usage() {
+    if [[ $SERVER_PRESENT ]]; then
+        echo "  Server:          typedb server [--help]"
+    fi
+    if [[ $CONSOLE_PRESENT ]]; then
+        echo "  Console:         typedb console [--help]"
+    fi
+}
+
 # =============================================
 # main routine
 # =============================================
 
 exit_if_java_not_found
 
-if [ -z "$1" ]; then
-    echo "Missing argument. Possible commands are:"
-    echo "  Server:          typedb server [--help]"
-    echo "  Enterprise:      typedb enterprise [--help]"
-    echo "  Console:         typedb console [--help]"
+if [[ ! $SERVER_PRESENT && ! $CONSOLE_PRESENT ]]; then
+    echo "TypeDB Console and Server are not installed!"
     exit 1
-elif [ "$1" = "console" ]; then
-    if [ -d "${TYPEDB_HOME}/console" ]; then
+
+else case "$1" in
+    console)
+        if [[ ! $CONSOLE_PRESENT ]]; then
+            echo "TypeDB Console not found. Make sure to install or download TypeDB Console."
+            exit 1
+        fi
+
         SERVICE_LIB_CP="console/lib/*"
         CLASSPATH="${TYPEDB_HOME}/${SERVICE_LIB_CP}:${TYPEDB_HOME}/console/conf/"
-    # exec replaces current shell process with java so no commands after this one will ever get executed
-        exec $JAVA_BIN ${JAVAOPTS} -cp "${CLASSPATH}" -Dtypedb.dir="${TYPEDB_HOME}" com.vaticle.typedb.console.TypeDBConsole "${@:2}"
-    else
-        echo "TypeDB Console is not found. Make sure to install or download TypeDB Console or TypeDB (all)."
-        exit 1
-    fi
-elif [[ "$1" = "server" ]] || [[ "$1" = "enterprise" ]]; then
+        # exec replaces current shell process with java so no commands after this one will ever get executed
+        exec ${JAVA_BIN} ${JAVAOPTS} -cp "${CLASSPATH}" -Dtypedb.dir="${TYPEDB_HOME}" com.vaticle.typedb.console.TypeDBConsole "${@:2}"
+        ;;
 
-    TYPEDB_SERVER_DIR="${TYPEDB_HOME}/server"
-    TYPEDB_SERVER_LIB_DIR="${TYPEDB_SERVER_DIR}/lib"
-    TYPEDB_ENTERPRISE_SERVER_JAR=("${TYPEDB_SERVER_LIB_DIR}"/com-vaticle-typedb-typedb-enterprise-server-*.jar)
+    server)
+        if [[ ! $SERVER_PRESENT ]]; then
+            echo "TypeDB Server not found. Make sure to install or download TypeDB."
+            exit 1
+        fi
 
-    CLASSPATH="${TYPEDB_SERVER_DIR}/conf/:${TYPEDB_SERVER_LIB_DIR}/*"
-
-    if [[ "$1" = "server" ]]; then
-        TYPEDB_ALL_NAME="TypeDB (All)"
-        TYPEDB_SERVER_NAME="TypeDB (Server)"
-        TYPEDB_SERVER_CLASS=com.vaticle.typedb.core.server.TypeDBServer
+        TYPEDB_SERVER_LIB_DIR="${TYPEDB_SERVER_DIR}/lib"
+        TYPEDB_ENTERPRISE_SERVER_JAR=("${TYPEDB_SERVER_LIB_DIR}"/com-vaticle-typedb-typedb-enterprise-server-*.jar)
 
         if [[ -f "$TYPEDB_ENTERPRISE_SERVER_JAR" ]]; then
-            echo "$TYPEDB_SERVER_NAME is not found. Make sure to install or download $TYPEDB_SERVER_NAME or $TYPEDB_ALL_NAME."
-            exit 1
+            TYPEDB_SERVER_CLASS=com.vaticle.typedb.enterprise.server.TypeDBEnterpriseServer
+        else
+            TYPEDB_SERVER_CLASS=com.vaticle.typedb.core.server.TypeDBServer
         fi
-    else
-        TYPEDB_ALL_NAME="TypeDB Enterprise (All)"
-        TYPEDB_SERVER_NAME="TypeDB Enterprise (Server)"
-        TYPEDB_SERVER_CLASS=com.vaticle.typedb.enterprise.server.TypeDBEnterpriseServer
 
-        if [[ ! -f "$TYPEDB_ENTERPRISE_SERVER_JAR" ]]; then
-            echo "$TYPEDB_SERVER_NAME is not found. Make sure to install or download $TYPEDB_SERVER_NAME or $TYPEDB_ALL_NAME."
-            exit 1
-        fi
-    fi
+        IDX=0
+        while [[ "${@:IDX}" ]]; do
+            case ${@:IDX:1} in
+                --debug) EXTRA_OPTS=-ea
+                break;
+            esac
+            IDX=$((IDX+1))
+        done
 
-    IDX=0
-    while [[ "${@:IDX}" ]]; do
-        case ${@:IDX:1} in
-            --debug) DEBUG=yes;
-            break;
-        esac
-        IDX=$((IDX+1))
-    done
+        CLASSPATH="${TYPEDB_SERVER_DIR}/conf/:${TYPEDB_SERVER_LIB_DIR}/*"
 
-    # exec replaces current shell process with java so no commands after these ones will ever get executed
-    if [ $DEBUG ]; then
-        exec $JAVA_BIN ${JAVAOPTS} -ea -cp "${CLASSPATH}" -Dtypedb.dir="${TYPEDB_HOME}" \
-            ${TYPEDB_SERVER_CLASS} "${@:2}"
-    else
-        exec $JAVA_BIN ${JAVAOPTS} -cp "${CLASSPATH}" -Dtypedb.dir="${TYPEDB_HOME}" \
-            ${TYPEDB_SERVER_CLASS} "${@:2}"
-    fi
-else
-    echo "Invalid argument: $1. Possible commands are: "
-    echo "  Server:          typedb server [--help]"
-    echo "  Enterprise:      typedb enterprise [--help]"
-    echo "  Console:         typedb console [--help]"
-    exit 1
+        # exec replaces current shell process with java so no commands after these ones will ever get executed
+        exec ${JAVA_BIN} ${JAVAOPTS} ${EXTRA_OPTS} -cp "${CLASSPATH}" -Dtypedb.dir="${TYPEDB_HOME}" ${TYPEDB_SERVER_CLASS} "${@:2}"
+        ;;
+
+    "")
+        echo "Missing argument. Possible commands are:"
+        print_usage
+        exit 1
+        ;;
+    *)
+        echo "Invalid argument: $1. Possible commands are: "
+        print_usage
+        exit 1
+        ;;
+    esac
 fi
-

--- a/binary/typedb
+++ b/binary/typedb
@@ -90,9 +90,10 @@ else case "$1" in
         fi
 
         IDX=0
+        EXTRAOPTS=
         while [[ "${@:IDX}" ]]; do
             case ${@:IDX:1} in
-                --debug) EXTRA_OPTS=-ea
+                --debug) EXTRAOPTS=-ea
                 break;
             esac
             IDX=$((IDX+1))
@@ -101,7 +102,7 @@ else case "$1" in
         CLASSPATH="${TYPEDB_SERVER_DIR}/conf/:${TYPEDB_SERVER_LIB_DIR}/*"
 
         # exec replaces current shell process with java so no commands after these ones will ever get executed
-        exec ${JAVA_BIN} ${JAVAOPTS} ${EXTRA_OPTS} -cp "${CLASSPATH}" -Dtypedb.dir="${TYPEDB_HOME}" ${TYPEDB_SERVER_CLASS} "${@:2}"
+        exec ${JAVA_BIN} ${JAVAOPTS} ${EXTRAOPTS} -cp "${CLASSPATH}" -Dtypedb.dir="${TYPEDB_HOME}" ${TYPEDB_SERVER_CLASS} "${@:2}"
         ;;
 
     "")

--- a/binary/typedb.bat
+++ b/binary/typedb.bat
@@ -43,7 +43,7 @@ goto print_usage
 
 set "G_CP=%TYPEDB_HOME%\console\conf\;%TYPEDB_HOME%\console\lib\*"
 if exist "%TYPEDB_HOME%\console\" (
-  start java %CONSOLE_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.console.TypeDBConsole %2 %3 %4 %5 %6 %7 %8 %9
+  java %CONSOLE_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.console.TypeDBConsole %2 %3 %4 %5 %6 %7 %8 %9
   goto exit
 ) else (
   echo TypeDB Console is not included in this TypeDB distribution^.
@@ -62,7 +62,11 @@ echo "%G_CP%"
 echo "%TYPEDB_HOME%"
 
 if exist "%TYPEDB_HOME%\server\" (
-  start java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.core.server.TypeDBServer %2 %3 %4 %5 %6 %7 %8 %9
+  if "%2"=="--help" (
+    java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.core.server.TypeDBServer %2 %3 %4 %5 %6 %7 %8 %9
+  ) else (
+    start java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.core.server.TypeDBServer %2 %3 %4 %5 %6 %7 %8 %9
+  )
   goto exit
 ) else (
   goto server_not_found
@@ -73,19 +77,23 @@ if exist "%TYPEDB_HOME%\server\" (
 set "G_CP=%TYPEDB_HOME%\server\conf\;%TYPEDB_HOME%\server\lib\*"
 
 if exist "%TYPEDB_HOME%\server\" (
-  start java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.enterprise.server.TypeDBEnterpriseServer %2 %3 %4 %5 %6 %7 %8 %9
+  if "%2"=="--help" (
+    java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.enterprise.server.TypeDBEnterpriseServer %2 %3 %4 %5 %6 %7 %8 %9
+  ) else (
+    start java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.enterprise.server.TypeDBEnterpriseServer %2 %3 %4 %5 %6 %7 %8 %9
+  )
   goto exit
 ) else (
   goto server_not_found
 )
 
+:exit
+exit /b 0
+
 :server_not_found
 echo TypeDB Server is not included in this TypeDB distribution^.
 echo You may want to install TypeDB^.
 goto exiterror
-
-:exit
-exit /b 0
 
 :print_usage
 if exist "%TYPEDB_HOME%\server\" (
@@ -94,6 +102,7 @@ if exist "%TYPEDB_HOME%\server\" (
 if exist "%TYPEDB_HOME%\console\" (
   echo   Console:         typedb console [--help]
 )
+goto exiterror
 
 :exiterror
 exit /b 1

--- a/binary/typedb.bat
+++ b/binary/typedb.bat
@@ -25,7 +25,6 @@ if %ERRORLEVEL% GEQ 1 (
   exit 1
 )
 
-
 if "%1" == "" goto missingargument
 
 if "%1" == "console" goto startconsole
@@ -65,7 +64,7 @@ if exist "%TYPEDB_HOME%\server\" (
   if "%2"=="--help" (
     java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.core.server.TypeDBServer %2 %3 %4 %5 %6 %7 %8 %9
   ) else (
-    start java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.core.server.TypeDBServer %2 %3 %4 %5 %6 %7 %8 %9
+    start cmd /c java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.core.server.TypeDBServer %2 %3 %4 %5 %6 %7 %8 %9 ^|^| pause
   )
   goto exit
 ) else (
@@ -80,7 +79,7 @@ if exist "%TYPEDB_HOME%\server\" (
   if "%2"=="--help" (
     java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.enterprise.server.TypeDBEnterpriseServer %2 %3 %4 %5 %6 %7 %8 %9
   ) else (
-    start java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.enterprise.server.TypeDBEnterpriseServer %2 %3 %4 %5 %6 %7 %8 %9
+    start cmd /c java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.enterprise.server.TypeDBEnterpriseServer %2 %3 %4 %5 %6 %7 %8 %9 ^|^| pause
   )
   goto exit
 ) else (

--- a/binary/typedb.bat
+++ b/binary/typedb.bat
@@ -20,33 +20,24 @@ IF %TYPEDB_HOME:~-1%==\ SET TYPEDB_HOME=%TYPEDB_HOME:~0,-1%
 
 where java >NUL 2>NUL
 if %ERRORLEVEL% GEQ 1 (
-    echo Java is not installed on this machine.
-    echo TypeDB needs Java 11+ in order to run. See the following setup guide: http://docs.vaticle.com/docs/get-started/setup-guide
-    pause
-    exit 1
+  echo Java is not installed on this machine. TypeDB needs Java 11+ in order to run.
+  pause
+  exit 1
 )
 
 
 if "%1" == "" goto missingargument
 
 if "%1" == "console" goto startconsole
-if "%1" == "enterprise" goto startenterprise
 if "%1" == "server"  goto startserver
 
 echo   Invalid argument: %1. Possible commands are:
-echo   Server:          typedb server [--help]
-echo   Enterprise:      typedb enterprise [--help]
-echo   Console:         typedb console [--help]
-goto exiterror
+goto print_usage
 
 :missingargument
 
  echo   Missing argument. Possible commands are:
- echo   Server:          typedb server [--help]
- echo   Enterprise:      typedb enterprise [--help]
- echo   Console:         typedb console [--help]
-
-goto exiterror
+goto print_usage
 
 :startconsole
 
@@ -56,11 +47,15 @@ if exist "%TYPEDB_HOME%\console\" (
   goto exit
 ) else (
   echo TypeDB Console is not included in this TypeDB distribution^.
-  echo You may want to install TypeDB Console or TypeDB ^(all^)^.
+  echo You may want to install TypeDB Console^.
   goto exiterror
 )
 
 :startserver
+
+if exist "%TYPEDB_HOME%\server\com-vaticle-typedb-typedb-enterprise-server-*.jar" (
+  goto startenterprise
+)
 
 set "G_CP=%TYPEDB_HOME%\server\conf\;%TYPEDB_HOME%\server\lib\*"
 echo "%G_CP%"
@@ -70,9 +65,7 @@ if exist "%TYPEDB_HOME%\server\" (
   start java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.core.server.TypeDBServer %2 %3 %4 %5 %6 %7 %8 %9
   goto exit
 ) else (
-  echo TypeDB Server is not included in this TypeDB distribution^.
-  echo You may want to install TypeDB Server or TypeDB ^(all^)^.
-  goto exiterror
+  goto server_not_found
 )
 
 :startenterprise
@@ -83,14 +76,24 @@ if exist "%TYPEDB_HOME%\server\" (
   start java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dtypedb.dir="%TYPEDB_HOME%" com.vaticle.typedb.enterprise.server.TypeDBEnterpriseServer %2 %3 %4 %5 %6 %7 %8 %9
   goto exit
 ) else (
-  echo TypeDB Enterprise is not included in this TypeDB distribution^.
-  echo You may want to install TypeDB Enterprise ^(all^)^.
-  goto exiterror
+  goto server_not_found
 )
 
+:server_not_found
+echo TypeDB Server is not included in this TypeDB distribution^.
+echo You may want to install TypeDB^.
+goto exiterror
 
 :exit
 exit /b 0
+
+:print_usage
+if exist "%TYPEDB_HOME%\server\" (
+  echo   Server:          typedb server [--help]
+)
+if exist "%TYPEDB_HOME%\console\" (
+  echo   Console:         typedb console [--help]
+)
 
 :exiterror
 exit /b 1

--- a/test/enterprise/TypeDBEnterpriseServerRunner.java
+++ b/test/enterprise/TypeDBEnterpriseServerRunner.java
@@ -121,7 +121,7 @@ public interface TypeDBEnterpriseServerRunner extends TypeDBRunner {
 
         public List<String> command() {
             List<String> cmd = new ArrayList<>();
-            cmd.add("enterprise");
+            cmd.add("server");
             serverOptions.forEach((key, value) -> cmd.add(key + "=" + value));
             return Util.typeDBCommand(cmd);
         }


### PR DESCRIPTION
## What is the goal of this PR?

We provide a single `server` entry point for starting up both core and enterprise server, whichever happens to be installed. We also omit `server` or `console` from the usage help if it is not present to avoid confusion. See https://github.com/vaticle/typedb/issues/6942 for more details.

We also improve the UX of the windows version of the entry point. Console no longer opens in a new window, `--help` is printed inline as expected, and in the event of the server failure, the logs are displayed to the user.
