### PR TITLE
Fix line endings for TypeDB batch launcher

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,19 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 *.bat   text eol=crlf
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.bat   text eol=crlf
+

--- a/BUILD
+++ b/BUILD
@@ -78,6 +78,7 @@ checkstyle_test(
     include = glob([
         ".bazelrc",
         ".gitignore",
+        ".gitattributes",
         ".factory/automation.yml",
         "BUILD",
         "WORKSPACE",

--- a/binary/typedb.bat
+++ b/binary/typedb.bat
@@ -35,7 +35,7 @@ goto print_usage
 
 :missingargument
 
- echo   Missing argument. Possible commands are:
+echo   Missing argument. Possible commands are:
 goto print_usage
 
 :startconsole
@@ -105,3 +105,4 @@ goto exiterror
 
 :exiterror
 exit /b 1
+


### PR DESCRIPTION
## What is the goal of this PR?

When launching the server, a bug caused additional output that claimed a batch label that did exist, didn't. We've corrected the line endings from LF to CRLF on TypeDB's batch launcher.

## What are the changes implemented in this PR?

As above.
* Changed the line endings on typedb.bat.
* Added a gitattributes file to specify the above requirement for bat files for the future. 
* Added checkstyle for the above new file.
* Added an end of line and fixed a space.

## Notes

The line endings change seems to be invisible to git and GitHub's changes viewer. To verify this change, checkout and run `cat -ev binary/typedb.bat` to see the new line endings.