### PR TITLE
Migrate artifact hosting to cloudsmith 

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -56,8 +56,8 @@ build:
       image: vaticle-ubuntu-22.04
       dependencies: [build]
       command: |
-        export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //:deploy-maven -- snapshot
 release:
   filter:
@@ -75,6 +75,6 @@ release:
       image: vaticle-ubuntu-22.04
       dependencies: [deploy-github]
       command: |
-        export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(cat VERSION) //:deploy-maven -- release

--- a/BUILD
+++ b/BUILD
@@ -69,8 +69,8 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
-    snapshot = deployment['maven.snapshot'],
-    release = deployment['maven.release']
+    snapshot = deployment['maven']['snapshot']['upload'],
+    release = deployment['maven']['release']['upload']
 )
 
 checkstyle_test(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,6 +78,12 @@ rules_pkg_dependencies()
 load("@vaticle_bazel_distribution//github:deps.bzl", github_deps = "deps")
 github_deps()
 
+# Load @vaticle_bazel_distribution_cloudsmith
+load("@vaticle_bazel_distribution//common/cloudsmith:deps.bzl", cloudsmith_deps = "deps")
+cloudsmith_deps()
+load("@vaticle_bazel_distribution_cloudsmith//:requirements.bzl", install_cloudsmith_deps = "install_deps")
+install_cloudsmith_deps()
+
 ################################
 # Load @vaticle dependencies #
 ################################

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,9 +79,9 @@ load("@vaticle_bazel_distribution//github:deps.bzl", github_deps = "deps")
 github_deps()
 
 # Load @vaticle_bazel_distribution_cloudsmith
-load("@vaticle_bazel_distribution//common/cloudsmith:deps.bzl", cloudsmith_deps = "deps")
+load("@vaticle_bazel_distribution//common/uploader:deps.bzl", cloudsmith_deps = "deps")
 cloudsmith_deps()
-load("@vaticle_bazel_distribution_cloudsmith//:requirements.bzl", install_cloudsmith_deps = "install_deps")
+load("@vaticle_bazel_distribution_uploader//:requirements.bzl", install_cloudsmith_deps = "install_deps")
 install_cloudsmith_deps()
 
 ################################

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,6 +20,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "1200b4aef118e75ca070c4944e9459b2aab7982a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/krishnangovindraj/dependencies",
+        commit = "3855727ed3f6d93ccc5f176f4414e0142ca718a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,6 +20,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "3855727ed3f6d93ccc5f176f4414e0142ca718a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "9632621e9e6381e192ba744ccb3f7447d0433c19", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )


### PR DESCRIPTION
## What is the goal of this PR?
Updates artifact deployment & consumption rules to use cloudsmith instead of the self-hosted sonatype repository.

## What are the changes implemented in this PR?
* Updates deployment rules to point to Cloudsmith

