### PR TITLE
Sync dependencies in CI

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -59,6 +59,16 @@ build:
         export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //:deploy-maven -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //test:deploy-maven -- snapshot
+    sync-dependencies:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies: [deploy-maven-snapshot]
+      command: |
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
 release:
   filter:
     owner: vaticle
@@ -78,3 +88,13 @@ release:
         export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(cat VERSION) //:deploy-maven -- release
+        bazel run --define version=$(cat VERSION) //test:deploy-maven -- release
+    sync-dependencies-release:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies: [deploy-github, deploy-maven-release]
+      command: |
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@$(cat VERSION)

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -59,7 +59,6 @@ build:
         export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //:deploy-maven -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //test:deploy-maven -- snapshot
     sync-dependencies:
       image: vaticle-ubuntu-22.04
       filter:
@@ -88,7 +87,6 @@ release:
         export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(cat VERSION) //:deploy-maven -- release
-        bazel run --define version=$(cat VERSION) //test:deploy-maven -- release
     sync-dependencies-release:
       image: vaticle-ubuntu-22.04
       filter:


### PR DESCRIPTION
## Usage and product changes

We add a sync-dependencies job to be run in CI after successful snapshot and release deployments. The job sends a request to vaticle-bot to update all downstream dependencies.

Note: this PR does _not_ update the `dependencies` repo dependency. It will be updated automatically by the bot during its first pass.