### PR TITLE
Remove SonarCloud analysis job

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -25,13 +25,6 @@ build:
     filter:
       owner: vaticle
       branch: [master, development]
-    build-analysis:
-      image: vaticle-ubuntu-22.04
-      command: |
-        SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
-          bazel run @vaticle_dependencies//tool/sonarcloud:code-analysis -- \
-          --project-key=vaticle_typedb_common \
-          --branch=$FACTORY_BRANCH --commit-id=$FACTORY_COMMIT
     dependency-analysis:
       image: vaticle-ubuntu-22.04
       command: |


### PR DESCRIPTION
## What is the goal of this PR?

The Sonarcloud code analysis results were unused for a while now. With Sonarcloud ending support for Java 11 in January 2024, and with Vaticle transitioning to primarily Rust organisation, a language not supported by Sonar static analysis, this job has been made redundant.